### PR TITLE
Use the user's shell

### DIFF
--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -114,11 +114,11 @@ proc handleMessage(msg: MessageRecv): string =
                 reply.code = some(1)
 
         of "run":
-            reply.content = some $(if defined(windows):
-                execProcess("cmd", args=["/c", msg.command.get()], options={poStdErrToStdOut})
+            when defined(windows):
+                reply.content = some $execProcess("cmd", args=["/c", msg.command.get()], options={poStdErrToStdOut})
             else:
-                execProcess(msg.command.get(), options={poEvalCommand, poStdErrToStdOut})
-            )
+                reply.content = some $execProcess(msg.command.get(), options={poEvalCommand, poStdErrToStdOut})
+
             reply.code = some 0
             # probably important to catch the exit code so we can `:cq` in Vim to cancel Ctrl-I
 

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -114,9 +114,11 @@ proc handleMessage(msg: MessageRecv): string =
                 reply.code = some(1)
 
         of "run":
-            # this seems to use /bin/sh rather than the user's shell
-            let (shell, switch) = (if defined(windows): ("cmd", "/c") else: (getEnv("SHELL", "/bin/sh"), "-c"))
-            reply.content = some($ execProcess(shell, args=[switch, msg.command.get()], options={poStdErrToStdOut}))
+            reply.content = some $(if defined(windows):
+                execProcess("cmd", args=["/c", msg.command.get()], options={poStdErrToStdOut})
+            else:
+                execProcess(msg.command.get(), options={poEvalCommand, poStdErrToStdOut})
+            )
             reply.code = some 0
             # probably important to catch the exit code so we can `:cq` in Vim to cancel Ctrl-I
 

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -115,7 +115,8 @@ proc handleMessage(msg: MessageRecv): string =
 
         of "run":
             # this seems to use /bin/sh rather than the user's shell
-            reply.content = some($ execProcess(msg.command.get(), options={poEvalCommand,poStdErrToStdOut}))
+            let (shell, switch) = (if defined(windows): ("cmd", "/c") else: (getEnv("SHELL", "/bin/sh"), "-c"))
+            reply.content = some($ execProcess(shell, args=[switch, msg.command.get()], options={poStdErrToStdOut}))
             reply.code = some 0
             # probably important to catch the exit code so we can `:cq` in Vim to cancel Ctrl-I
 


### PR DESCRIPTION
This makes the "run" command really slow if you're using a big shell like `fish`, ~0.3s (compared to Python's 0.1s).

The current Python messenger executes everything in `/bin/sh` anyway. @Rummskartoffel can you remember why I was trying to do this? What does the current Python messenger do on Windows?