### PR TITLE
Add new Windows installer

### DIFF
--- a/installers/windows.ps1
+++ b/installers/windows.ps1
@@ -6,13 +6,13 @@
     to "$env:USERPROFILE\.tridactyl".
 .Parameter Tag
     The Tridactyl version to which the corresponding version of the native
-    messenger should be installed. Tridactyl versions lower than 1.20.5 are not
+    messenger should be installed. Tridactyl versions lower than 1.21.0 are not
     supported.
 #>
 Param (
     [switch]$Uninstall = $false,
     [string]$InstallDirectory = "$env:USERPROFILE\.tridactyl",
-    [string]$Tag = "1.20.5"
+    [string]$Tag = "1.21.0"
 )
 
 function Install-NativeMessenger {
@@ -32,7 +32,7 @@ function Install-NativeMessenger {
     Write-Output "Downloading manifest"
     (Invoke-WebRequest `
             "https://raw.githubusercontent.com/tridactyl/native_messenger/$MessengerVersion/tridactyl.json").`
-        Content.Replace("REPLACE_ME_WITH_SED", "native_main.bat") |
+        Content.Replace("REPLACE_ME_WITH_SED", "native_main.exe") |
         Set-Content -Path "tridactyl.json"
 
     Write-Output "Registering native messenger"
@@ -43,10 +43,6 @@ function Install-NativeMessenger {
         -Name "(default)" -PropertyType String `
         -Value $((Get-Item "tridactyl.json").FullName) `
         -Force > $null
-
-    Write-Output "Creating launcher"
-    "@echo off`ncall .\native_main.exe %*" |
-        Set-Content -Path "native_main.bat"
 
     Copy-Item $PSCommandPath "installer.ps1"
 
@@ -71,7 +67,7 @@ function Uninstall-NativeMessenger {
             @("&Yes", "&No"), 1) -eq 1) {
         Write-Output "Uninstallation cancelled"
         exit
-    } 
+    }
 
     Write-Output "Unregistering messenger"
     Remove-Item -Path "HKCU:\SOFTWARE\Mozilla\NativeMessagingHosts\tridactyl" `
@@ -80,9 +76,8 @@ function Uninstall-NativeMessenger {
     Write-Output "Entering $MessengerDirectory"
     Push-Location $MessengerDirectory
 
-    Write-Output "Deleting messenger, manifest, launcher, and installer"
-    Get-ChildItem "native_main.exe", "tridactyl.json", "native_main.bat", `
-        "installer.ps1" | Remove-Item
+    Write-Output "Deleting messenger, manifest, and installer"
+    Get-ChildItem "native_main.exe", "tridactyl.json", "installer.ps1" | Remove-Item
 
     Write-Output "Exiting $MessengerDirectory"
     Pop-Location

--- a/installers/windows.ps1
+++ b/installers/windows.ps1
@@ -1,0 +1,96 @@
+<#
+.Parameter Uninstall
+    Whether to uninstall an existing native messenger installation.
+.Parameter InstallDirectory
+    The directory in which the native messenger should be installed. Defaults
+    to "$env:USERPROFILE\.tridactyl".
+.Parameter Tag
+    The Tridactyl version to which the corresponding version of the native
+    messenger should be installed. Tridactyl versions lower than 1.20.5 are not
+    supported.
+#>
+Param (
+    [switch]$Uninstall = $false,
+    [string]$InstallDirectory = "$env:USERPROFILE\.tridactyl",
+    [string]$Tag = "1.20.5"
+)
+
+function Install-NativeMessenger {
+    $MessengerVersion = (Invoke-WebRequest `
+            "https://raw.githubusercontent.com/tridactyl/tridactyl/$Tag/native/current_native_version").`
+        Content.Trim()
+    Write-Output "Installing native messenger version $MessengerVersion in $InstallDirectory"
+
+    Write-Output "Entering $InstallDirectory"
+    Push-Location $InstallDirectory
+
+    Write-Output "Downloading native messenger"
+    Invoke-WebRequest `
+        "https://github.com/tridactyl/native_messenger/releases/download/$MessengerVersion/native_main-Windows" `
+        -OutFile "native_main.exe"
+
+    Write-Output "Downloading manifest"
+    (Invoke-WebRequest `
+            "https://raw.githubusercontent.com/tridactyl/native_messenger/$MessengerVersion/tridactyl.json").`
+        Content.Replace("REPLACE_ME_WITH_SED", "native_main.bat") |
+        Set-Content -Path "tridactyl.json"
+
+    Write-Output "Registering native messenger"
+    New-Item -ItemType Directory `
+        "HKCU:\SOFTWARE\Mozilla\NativeMessagingHosts\tridactyl" `
+        -Force > $null
+    New-ItemProperty -Path "HKCU:\SOFTWARE\Mozilla\NativeMessagingHosts\tridactyl" `
+        -Name "(default)" -PropertyType String `
+        -Value $((Get-Item "tridactyl.json").FullName) `
+        -Force > $null
+
+    Write-Output "Creating launcher"
+    "@echo off`ncall .\native_main.exe %*" |
+        Set-Content -Path "native_main.bat"
+
+    Copy-Item $PSCommandPath "installer.ps1"
+
+    Write-Output "Exiting $InstallDirectory"
+    Pop-Location
+    Write-Output "Done"
+    Write-Output @"
+The installer for the native messenger has been copied to $InstallDirectory.
+To uninstall the native messenger, navigate to that directory in Powershell
+and run ".\installer.ps1 -Uninstall".
+"@
+    exit
+}
+
+function Uninstall-NativeMessenger {
+    $MessengerDirectory = Get-ItemPropertyValue `
+        -Path "HKCU:\SOFTWARE\Mozilla\NativeMessagingHosts\tridactyl" -Name "(default)" |
+        Get-Item | Select-Object -ExpandProperty Directory
+
+    if ($Host.UI.PromptForChoice("Uninstall native messenger", `
+                "Are you sure you want to uninstall the native messenger from $MessengerDirectory`?",
+            @("&Yes", "&No"), 1) -eq 1) {
+        Write-Output "Uninstallation cancelled"
+        exit
+    } 
+
+    Write-Output "Unregistering messenger"
+    Remove-Item -Path "HKCU:\SOFTWARE\Mozilla\NativeMessagingHosts\tridactyl" `
+        -Force -Recurse
+
+    Write-Output "Entering $MessengerDirectory"
+    Push-Location $MessengerDirectory
+
+    Write-Output "Deleting messenger, manifest, launcher, and installer"
+    Get-ChildItem "native_main.exe", "tridactyl.json", "native_main.bat", `
+        "installer.ps1" | Remove-Item
+
+    Write-Output "Exiting $MessengerDirectory"
+    Pop-Location
+    Write-Output "Done"
+}
+
+if ($Uninstall) {
+    Uninstall-NativeMessenger
+} else {
+    Install-NativeMessenger
+}

--- a/installers/windows.ps1
+++ b/installers/windows.ps1
@@ -58,13 +58,17 @@ and run ".\installer.ps1 -Uninstall".
 }
 
 function Uninstall-NativeMessenger {
-    $MessengerDirectory = Get-ItemPropertyValue `
-        -Path "HKCU:\SOFTWARE\Mozilla\NativeMessagingHosts\tridactyl" -Name "(default)" |
+    $MessengerDirectory = (Get-ItemProperty `
+            -Path "HKCU:\SOFTWARE\Mozilla\NativeMessagingHosts\tridactyl")."(default)" |
         Get-Item | Select-Object -ExpandProperty Directory
 
+    $yes = New-Object System.Management.Automation.Host.ChoiceDescription `
+        "&Yes", "Uninstall the native messenger."
+    $no = New-Object System.Management.Automation.Host.ChoiceDescription `
+        "&No", "Do nothing."
     if ($Host.UI.PromptForChoice("Uninstall native messenger", `
                 "Are you sure you want to uninstall the native messenger from $MessengerDirectory`?",
-            @("&Yes", "&No"), 1) -eq 1) {
+            @($yes, $no), 1) -eq 1) {
         Write-Output "Uninstallation cancelled"
         exit
     }

--- a/tridactyl.json
+++ b/tridactyl.json
@@ -1,0 +1,7 @@
+{
+    "name": "tridactyl",
+    "description": "Tridactyl native command handler",
+    "path": "REPLACE_ME_WITH_SED",
+    "type": "stdio",
+    "allowed_extensions": [ "tridactyl.vim@cmcaine.co.uk","tridactyl.vim.betas@cmcaine.co.uk", "tridactyl.vim.betas.nonewtab@cmcaine.co.uk" ]
+}


### PR DESCRIPTION
I've added the `native_main.bat` launcher for now, but I don't think it's necessary, since Firefox can now just run the binary directly.
I've not yet tested this in Powershell 3.x, which is used on Windows 8 – I'm on Windows 10, which has Powershell 5.1, so I might be using some features that don't exist on lower versions.
As I already announced, this installer isn't backwards-compatible with the old one. Honestly, if anybody was automating that, I think that's their fault.
One thing this installer is distinctly unable to do is clean up the old Python messenger. If we want that, it'd be trivial to add that to the uninstall function, though.