### PR TITLE
Fix running command line with more than a single word under MSW

### DIFF
--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -104,9 +104,11 @@ proc handleMessage(msg: MessageRecv): string =
                 reply.code = some(1)
 
         of "run":
-            var command = msg.command.get()
             when defined(windows):
-                command = "cmd /c " & command
+                let command = "cmd /c " & msg.command.get()
+            else:
+                let command = msg.command.get()
+
             let process = startProcess(command, options={poEvalCommand, poStdErrToStdOut})
 
             # Nicked from https://github.com/nim-lang/Nim/blob/1d8b7aa07ca9989b80dd758d66c7f4ba7dc533f7/lib/pure/osproc.nim#L507

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -104,10 +104,10 @@ proc handleMessage(msg: MessageRecv): string =
                 reply.code = some(1)
 
         of "run":
+            var command = msg.command.get()
             when defined(windows):
-                let process = startProcess("cmd", args=["/c", msg.command.get()], options={poStdErrToStdOut})
-            else:
-                let process = startProcess(msg.command.get(), options={poEvalCommand, poStdErrToStdOut})
+                command = "cmd /c " & command
+            let process = startProcess(command, options={poEvalCommand, poStdErrToStdOut})
 
             # Nicked from https://github.com/nim-lang/Nim/blob/1d8b7aa07ca9989b80dd758d66c7f4ba7dc533f7/lib/pure/osproc.nim#L507
             # Not 100% sure we can't just use readAll


### PR DESCRIPTION
Use poEvalCommand under Windows too to ensure that commands containing
quotes are parsed correctly.

Prepend "cmd /c" to the full command to still allow using built-ins.

Closes #18.

---

Alternative, and simpler, fix replacing #20.