### PR TITLE
Workaround for Nim's moveFile() issues on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 native_main.py
+native_main

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -11,7 +11,7 @@ import strutils
 import struct
 import tempfile
 
-const VERSION = "0.2.1"
+const VERSION = "0.2.3"
 var DEBUG = false
 
 type


### PR DESCRIPTION
Nim's os.moveFile() would fail to move files on MacOS Big-Sur 11.2 and
fail with the "operation not permitted" error. There are two underlying
issues:

1. Big-Sur's extended file attributes like the followings that mark
   files downloaded from the internet:

    - com.apple.quarantine
    - com.apple.metadata:kMDItemWhereFroms 


    As long as these attributes are there, MacOS 11.2 prevents
    moveFile() to function properly. This is worked around by invoking
    `xattr -d` on the attributes mentioned above.

2. However it seems even after the extended attributes are removed,
   moveFile() still tends to fail. This is worked around by using the
   POSIX compatible "mv" utility.

This patch was tested on two separate machines both running MacOS 11.2
with the Firefox Nightly 87.0a1 and Tridactyl 1.20.4pre5209-34b0fce4,
and everything seems to work on MacOS 11.2 so far.

Hope this helps. Thank you.