### PR TITLE
Update version to 0.2.3 and workaround for Nim's moveFile() issues on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 native_main.py
+native_main

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -184,8 +184,8 @@ proc handleMessage(msg: MessageRecv): string =
                 try:
                     when defined(macosx):
                         let mvCmd = quoteShellCommand([
-                                "mv", "-v",
-                                (if DEBUG: "-f" else: ""),
+                                "mv", "-f",
+                                (if DEBUG: "-v" else: ""),
                                 src, dst
                             ])
                         debug_log(">> mvCmd == " & $mvCmd & "\n")

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -182,6 +182,8 @@ proc handleMessage(msg: MessageRecv): string =
                 reply.code = some(1)
             else:
                 try:
+                    # On OSX, we use POSIX `mv` to bypass restrictions introduced in
+                    # Big Sur on moving files downloaded from the internet
                     when defined(macosx):
                         let mvCmd = quoteShellCommand([
                                 "mv", "-f",
@@ -278,4 +280,3 @@ while true:
     write(stdout, l)
     write(stdout, message) # %* converts the object to JSON
     flushFile(stdout)
-

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -11,7 +11,7 @@ import parseopt
 import struct
 import tempfile
 
-const VERSION = "0.2.1"
+const VERSION = "0.2.3"
 var DEBUG = false
 
 type

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -110,10 +110,12 @@ proc handleMessage(msg: MessageRecv): string =
 
     let cmd = msg.cmd.get()
     var reply: MessageResp
+    reply.cmd = some cmd
 
     case cmd:
         of "version":
             reply.version = some(VERSION)
+            reply.code = some 0
 
         of "getconfig":
             try:
@@ -141,6 +143,7 @@ proc handleMessage(msg: MessageRecv): string =
             else:
                 let command = msg.command.get()
 
+            reply.command = some command
             let process = startProcess(command, options={poEvalCommand, poStdErrToStdOut})
 
             # Nicked from https://github.com/nim-lang/Nim/blob/1d8b7aa07ca9989b80dd758d66c7f4ba7dc533f7/lib/pure/osproc.nim#L507

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -194,14 +194,14 @@ proc handleMessage(msg: MessageRecv): string =
                     when defined(macosx):
                         debug_log(">> MacOS detected ...\n")
                         var removeAttrErr = 0
-                        let attrsToRemove = @[
-                            "com.apple.quarantine",
-                            "com.apple.metadata:kMDItemWhereFroms"
-                        ]
-                        for attr in attrsToRemove:
-                            removeAttrErr = removeMacOSFileAttribute(src, attr)
-                            if removeAttrErr != 0:
-                                break
+                        # let attrsToRemove = @[
+                        #     "com.apple.quarantine",
+                        #     "com.apple.metadata:kMDItemWhereFroms"
+                        # ]
+                        # for attr in attrsToRemove:
+                        #     removeAttrErr = removeMacOSFileAttribute(src, attr)
+                        #     if removeAttrErr != 0:
+                        #         break
 
                         if removeAttrErr == 0:
                             var mvErr = 0

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -5,19 +5,21 @@ import streams
 import os
 import posix
 import strutils
+import parseopt
 
 # Third party stuff
 import struct
 import tempfile
 
 const VERSION = "0.2.1"
+var DEBUG = false
 
-type 
+type
     MessageRecv* = object
         cmd*, version*, content*, error*, command*, `var`*, file*, dir*, to*, `from`*, prefix*, path*: Option[string]
         force: Option[bool]
         code: Option[int]
-type 
+type
     MessageResp* = object
         cmd*, version*, content*, error*, command*, sep*: Option[string]
 
@@ -26,7 +28,7 @@ type
 
         isDir: Option[bool]
         code: Option[int]
-        
+
 # Vastly simpler than the Python version
 # Let's let users check if that matters : )
 proc sanitiseFilename(fn: string): string =
@@ -73,6 +75,34 @@ proc findUserConfigFile(): Option[string] =
 
     return config_path
 
+proc removeFileAttribute(file, attr: string): int =
+    var xattrErr = 0
+    var xattrCmd = ""
+
+    if DEBUG:
+        xattrCmd = quoteShellCommand(["xattr", "-d", attr, file])
+        write(stderr, ">> xattrCmd == " & $xattrCmd & "\n")
+    else:
+        xattrCmd = quoteShellCommand(["xattr", "-d", attr, file])
+
+    xattrErr = execCmd(xattrCmd)
+    return xattrErr
+
+proc parseCommandLineOptions() =
+    when declared(commandLineParams):
+        var p = initOptParser(commandLineParams())
+        while true:
+            p.next()
+            case p.kind
+            of cmdEnd:
+                break
+            of cmdShortOption, cmdLongOption:
+                if p.key == "debug" or p.key == "d":
+                    DEBUG = true
+            of cmdArgument:
+                continue
+    else:
+        write(stderr, ">> commandLineParams() is undefined on this system ...\n")
 
 proc handleMessage(msg: MessageRecv): string =
 
@@ -152,15 +182,48 @@ proc handleMessage(msg: MessageRecv): string =
                 reply.code = some(2)
 
         of "move":
-            let
-                dest = expandTilde(msg.to.get())
-                src  = expandTilde(msg.`from`.get())
-            if fileExists(dest):
+            let src = expandTilde(msg.from.get())
+            let dst = expandTilde(msg.to.get())
+
+            if fileExists(dst):
                 reply.code = some(1)
             else:
                 try:
-                    moveFile(src, dest)
-                    reply.code = some(0)
+                    when defined(macosx):
+                        if DEBUG:
+                            write(stderr, ">> MacOS detected ...\n")
+                        var removeAttrErr = 0
+                        let attrsToRemove = @[
+                            "com.apple.quarantine",
+                            "com.apple.metadata:kMDItemWhereFroms"
+                        ]
+                        for attr in attrsToRemove:
+                            removeAttrErr = removeFileAttribute(src, attr)
+                            if removeAttrErr != 0:
+                                break
+
+                        if removeAttrErr == 0:
+                            var mvErr = 0
+                            var mvCmd = ""
+                            if DEBUG:
+                                mvCmd = quoteShellCommand(["mv", "-v", "-f", src, dst])
+                                write(stderr, ">> mvCmd == " & $mvCmd & "\n")
+                            else:
+                                mvCmd = quoteShellCommand(["mv", "-f", src, dst])
+
+                            # moveFile(src, dst)
+                            mvErr = execCmd(mvCmd)
+                            if DEBUG:
+                                write(stderr, ">> mvErr == " & $mvErr & "\n")
+
+                            if mvErr == 0:
+                                reply.code = some(0)
+                            else:
+                                raise newException(OSError, "\"" & mvCmd & "\" failed on MacOS ...")
+                    else:
+                        moveFile(src, dst)
+                        reply.code = some(0)
+
                 except OSError:
                     reply.code = some(2)
 
@@ -232,6 +295,8 @@ proc handleMessage(msg: MessageRecv): string =
             write(stderr, "Unhandled message: " & $ msg & "\n")
 
     return $ %* reply # $ converts to string, %* converts to JSON
+
+parseCommandLineOptions()
 
 while true:
     let strm = newFileStream(stdin)

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -183,27 +183,19 @@ proc handleMessage(msg: MessageRecv): string =
             else:
                 try:
                     when defined(macosx):
-                        debug_log(">> MacOS detected ...\n")
-
                         let mvCmd = quoteShellCommand([
                                 "mv", "-v",
                                 (if DEBUG: "-f" else: ""),
                                 src, dst
                             ])
-
                         debug_log(">> mvCmd == " & $mvCmd & "\n")
-                        let mvErr = execCmd(mvCmd)
-
-                        debug_log(">> mvErr == " & $mvErr & "\n")
-
-                        if mvErr == 0:
-                            reply.code = some(0)
-                        else:
+                        reply.code = some execCmd(mvCmd)
+                        debug_log(">> mvStatus == " & $reply.code & "\n")
+                        if reply.code != 0:
                             raise newException(OSError, "\"" & mvCmd & "\" failed on MacOS ...")
                     else:
                         moveFile(src, dst)
                         reply.code = some(0)
-
                 except OSError:
                     reply.code = some(2)
 


### PR DESCRIPTION
Nim's os.moveFile() would fail to move files on MacOS Big-Sur 11.2 and
fail with the "operation not permitted" error. There are two underlying
issues:

1. Big-Sur's extended file attributes like the followings that mark
   files downloaded from the internet:

    - com.apple.quarantine
    - com.apple.metadata:kMDItemWhereFroms

    As long as these attributes are there, MacOS 11.2 prevents
    moveFile() to function properly. This is worked around by invoking
    `xattr -d` on the attributes mentioned above.

2. However it seems even after the extended attributes are removed,
   moveFile() still tends to fail. This is worked around by using the
   POSIX compatible "mv" utility.

This patch was tested on two separate machines both running MacOS 11.2
with the Firefox Nightly 87.0a1 and Tridactyl 1.20.4pre5209-34b0fce4,
and everything seems to work on MacOS 11.2 so far.

Hope this helps. Thank you.