### PR TITLE
Add --overwrite and --cleanup options to 'saveas'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 native_main.py
 native_main
+native_main.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 native_main.py
+native_main

--- a/gen_native_message.py
+++ b/gen_native_message.py
@@ -37,7 +37,12 @@ if __name__ == "__main__":
         for i in range(1, len(sys.argv)):
             key = sys.argv[i].strip().split(separator)[0]
             val = sys.argv[i].strip().split(separator)[1]
-            msg[key] = val
+            if val.lower() == "true":
+                msg[key] = True
+            elif val.lower() == "false":
+                msg[key] = False
+            else:
+                msg[key] = val
 
     if len(sys.argv) == 1:
         usage()

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -180,11 +180,13 @@ proc handleMessage(msg: MessageRecv): string =
             let overwrite = msg.overwrite.get(false)
             let cleanup = msg.cleanup.get(false)
 
+            var dstFileExists = false
             if overwrite == false:
                 if fileExists(dst) or fileExists(joinPath(dst, extractFilename(src))):
                     reply.code = some(1)
+                    dstFileExists = true
 
-            if overwrite == true:
+            if dstFileExists == false or overwrite == true:
                 try:
                     # On OSX, we use POSIX `mv` to bypass restrictions
                     # introduced in Big Sur on moving files downloaded

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -192,19 +192,12 @@ proc handleMessage(msg: MessageRecv): string =
                     # introduced in Big Sur on moving files downloaded
                     # from the internet
                     when defined(macosx):
-                        writeLog(">> macos detected ..." & "\n")
                         var mvCmd = quoteShellCommand([
                                 "mv",
-                                (when defined(DEBUG): "-v"),
-                                src, dst
+                                "-f",
+                                src,
+                                dst
                             ])
-                        if overwrite:
-                            mvCmd = quoteShellCommand([
-                                    "mv",
-                                    "-f",
-                                    (when defined(DEBUG): "-v"),
-                                    src, dst
-                                ])
 
                         writeLog(">> mvCmd == " & $mvCmd & "\n")
                         reply.code = some execCmd(mvCmd)
@@ -223,7 +216,6 @@ proc handleMessage(msg: MessageRecv): string =
                     let rmCmd = quoteShellCommand([
                             "rm",
                             "-f",
-                            (when defined(DEBUG): "-v"),
                             src
                         ])
                     writeLog(">> rmCmd == " & $rmCmd & "\n")
@@ -231,7 +223,7 @@ proc handleMessage(msg: MessageRecv): string =
                 else:
                     discard removeFile(src)
 
-            writeLog(">> reply.code == " & $reply.code & "\n")
+            writeLog(">> move() reply.code == " & $reply.code & "\n")
 
         of "write":
             try:
@@ -305,9 +297,11 @@ proc handleMessage(msg: MessageRecv): string =
 while true:
     let strm = newFileStream(stdin)
     let message = handleMessage(getMessage(strm))
-    writeLog(">> message ==" & message & "\n")
-    let l = pack("@I", message.len)
+    let message_length = pack("@I", message.len)
 
-    write(stdout, l)
-    write(stdout, message) # %* converts the object to JSON
+    writeLog(">> message ==" & message & "\n")
+    writeLog(">> message_length ==" & $message.len & "(" & $message_length & ")\n")
+
+    write(stdout, message_length)
+    write(stdout, $message)
     flushFile(stdout)

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -194,14 +194,14 @@ proc handleMessage(msg: MessageRecv): string =
                     when defined(macosx):
                         debug_log(">> MacOS detected ...\n")
                         var removeAttrErr = 0
-                        let attrsToRemove = @[
-                            "com.apple.quarantine",
-                            "com.apple.metadata:kMDItemWhereFroms"
-                        ]
-                        for attr in attrsToRemove:
-                            removeAttrErr = removeMacOSFileAttribute(src, attr)
-                            if removeAttrErr != 0:
-                                break
+                        # let attrsToRemove = @[
+                        #     "com.apple.quarantine",
+                        #     "com.apple.metadata:kMDItemWhereFroms"
+                        # ]
+                        # for attr in attrsToRemove:
+                        #     removeAttrErr = removeMacOSFileAttribute(src, attr)
+                        #     if removeAttrErr != 0:
+                        #         break
 
                         if removeAttrErr == 0:
                             var mvErr = 0

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -11,7 +11,7 @@ import strutils
 import struct
 import tempfile
 
-const VERSION = "0.2.1"
+const VERSION = "0.2.3"
 var DEBUG = false
 
 type

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -11,6 +11,7 @@ import strutils
 import struct
 import tempfile
 
+var DEBUG = false
 const NATIVE_MAIN_LOG = "native_main.log"
 const VERSION = "0.3.0"
 
@@ -32,13 +33,8 @@ type
         code: Option[int]
 
 proc writeLog(msg: string) =
-    # This function is mostly for debugging "native_main" invocations
-    # by the Firefox process. In order to enable logging, create/touch a
-    # file called "native_main.log" (as defined in NATIVE_MAIN_LOG
-    # variable above) in the same folder as the "native_main" binary. To
-    # stop logging, just delete this file.
-    let now = times.now()
-    if os.fileExists(NATIVE_MAIN_LOG):
+    if DEBUG:
+        let now = times.now()
         writeFile(NATIVE_MAIN_LOG, $now & " :: " & msg)
 
 # Vastly simpler than the Python version
@@ -292,6 +288,9 @@ proc handleMessage(msg: MessageRecv): string =
             write(stderr, "Unhandled message: " & $ msg & "\n")
 
     return $ %* reply # $ converts to string, %* converts to JSON
+
+if os.getEnv("TRIDACTYL_DEBUG") == "1":
+    DEBUG = true
 
 while true:
     let strm = newFileStream(stdin)


### PR DESCRIPTION
```
Some basic invocation of the :saveas command in Tridactyl could look
like the following:

- Example 1: :saveas ~/Documents/msg.doc Example 2: :saveas
- ~/Documents

In [1], saveas attempts to save a file called msg.doc inside
$HOME/Documents directory.

In [2], saveas attempts to save whatever file-name is provided by the
current URL and tries to save it in the ~/Documents directory. In this
example, it is possible that the user tries to download another document
called msg.doc from the current URL (which is different than the
existing one in ~/Documents) and unknowingly tries to save it inside
the ~/Documents directory resulting into a conflict. This can now be
avoided with the new --overwrite option described below.

- Example 3: saveas --overwrite ~/Documents/msg.doc
- Example 4: saveas --overwrite ~/Documents

If user specifies --overwrite as shown in example [3] and [4] either
with a file or directory target, the document downloaded from the
current URL would overwrite the target file e.g. inside ~/Docuemnts.

- Example 5: saveas --cleanup ~/Documents/msg.doc
- Example 6: saveas --cleanup ~/Documents

Similarly if --cleanup is specified, if the download and save/move
operation failed for any reason e.g. target file exists, the downloaded
file will be deleted from user's default downloads directory (usually
$HOME/Downloads). By default, the downloaded files that are failed to
be saved in the user specified location are not deleted and subsequent
saveas invocations on the same URL creates files like msg.doc(n) and
these are spuriously saved in the user specified location cluttering up
target directory and disk-space.

Hope this helps. Thank you.
```
