### PR TITLE
Windows 8, installer: New-Item explicit -ItemType

### DIFF
--- a/installers/windows.ps1
+++ b/installers/windows.ps1
@@ -49,7 +49,7 @@ function Install-NativeMessenger {
     $MessengerRequest = Invoke-WebRequest `
         "https://github.com/tridactyl/native_messenger/releases/download/$MessengerVersion/native_main-Windows"
     if (-not (Test-Path "native_main.exe")) {
-        New-Item "native_main.exe"
+        New-Item -ItemType File "native_main.exe"
     }
     for ($i = 0; $i -le 4; $i++) {
         try {


### PR DESCRIPTION
Required in PowerShell 4.0, so the install script fails without it.