### PR TITLE
Add an option to installers/install.sh which installs locally-build native_main

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ It therefore greatly increases the amount of damage bugs in Tridactyl can do to 
 
 # Installation
 
-Two options: run `:nativeinstall` in Tridactyl and follow the instructions. Otherwise download and run `installers/install.sh`, or `installers/windows.ps1` for Windows, from this repository
+Three options:
+
+- Run `:nativeinstall` in Tridactyl and follow the instructions.
+- Download and run `installers/install.sh`, or `installers/windows.ps1` for Windows, from this repository.
+- Clone the repository and build it locally, then run `./installers/install.sh local`.
 
 # Building
 

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -11,6 +11,8 @@ sedEscape() {
 }
 
 # To install, curl -fsSl 'url to this script' | sh
+# Or run "./installers/install.sh local" in the repository of the
+# native messanger.
 
 run() {
     set -e
@@ -43,14 +45,18 @@ run() {
             ;;
     esac
 
-    if [ -n "$1" ] ; then
-        native_version="$(curl -sSL https://raw.githubusercontent.com/tridactyl/tridactyl/"$1"/native/current_native_version 2>/dev/null)"
+    if [ "$1" = "local" ] ; then
+        manifest_loc="file://"$(pwd)"/tridactyl.json"
+        native_loc="file://"$(pwd)"/native_main"
     else
-        native_version="$(curl -sSL https://api.github.com/repos/tridactyl/native_messenger/releases/latest | grep "tag_name" | cut -d':' -f2- | sed 's|[^0-9\.]||g')"
+        if [ -n "$1" ] ; then
+            native_version="$(curl -sSL https://raw.githubusercontent.com/tridactyl/tridactyl/"$1"/native/current_native_version 2>/dev/null)"
+        else
+            native_version="$(curl -sSL https://api.github.com/repos/tridactyl/native_messenger/releases/latest | grep "tag_name" | cut -d':' -f2- | sed 's|[^0-9\.]||g')"
+        fi
+        manifest_loc="https://raw.githubusercontent.com/tridactyl/native_messenger/$native_version/tridactyl.json"
+        native_loc="https://github.com/tridactyl/native_messenger/releases/download/$native_version/native_main-$binary_suffix"
     fi
-    manifest_loc="https://raw.githubusercontent.com/tridactyl/native_messenger/$native_version/tridactyl.json"
-    native_loc="https://github.com/tridactyl/native_messenger/releases/download/$native_version/native_main-$binary_suffix"
-
 
     mkdir -p "$manifest_home" "$XDG_DATA_HOME"
 


### PR DESCRIPTION
This helps platforms where no official binary distribution is available. (I'm on NetBSD/amd64 by the way.)