### PR TITLE
Fix #64: swap PCRE for nim-regex

### DIFF
--- a/compile_and_test.sh
+++ b/compile_and_test.sh
@@ -6,5 +6,6 @@ chmod +x native_main
 cp native_main ~/.local/share/tridactyl/native_main
 time printf '%c\0\0\0{"cmd": "run", "command": "echo $PATH"}' 39 | ./native_main
 time printf '%c\0\0\0{"cmd": "version"}' 39 | ./native_main
+# time printf '%c\0\0\0{"cmd": "read", "file": "$HOME/test"}' 39 | ./native_main
 # time printf '%c\0\0\0{"cmd": "version"}' 39 | ~/.local/share/tridactyl/native_main.py # approx 100ms
 # time printf '%c\0\0\0{"cmd": "run", "command": "echo $PATH"}' 39 | ~/.local/share/tridactyl/native_main.py # approx 100ms

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -5,7 +5,7 @@ import streams
 import os
 import strutils
 import posix
-import re
+import regex
 import base64
 
 # Third party stuff
@@ -115,7 +115,10 @@ proc expandVars(path: string): string =
             name, value, tail: string
             (first, last) = (0, 0)
         while true:
-            (first, last) = findBounds(result, re"\$(\w+|\{[^}]*\})", first)
+            var bounds_slices = findAllBounds(result, re"\$(\w+|\{[^}]*\})", first)
+            if bounds_slices.len == 0:
+                break
+            (first, last) = (bounds_slices[0].a, bounds_slices[0].b)
             if first < 0 or last < first:
                 break
             name = result[first + 1 .. last]

--- a/tridactyl_native.nimble
+++ b/tridactyl_native.nimble
@@ -10,3 +10,4 @@ bin           = @["native_main"]
 
 requires "nim >= 1.2.0"
 requires "tempfile >= 0.1.0"
+requires "regex >= 0.20.2"


### PR DESCRIPTION
There's an iterator version of `findAllBounds` that presumably we could do something like `first(findAllBounds)` with to stop us having to iterate through the whole thing, but it's plenty fast enough so maybe we don't care