### PR TITLE
Make Linux builds statically linked

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -40,7 +40,7 @@ jobs:
 
       - run: |
           sudo apt-get install gcc-arm-linux-gnueabihf
-          nimble build -d:debug -Y --cpu:arm
+          nimble build -d:debug -Y --cpu:arm -l:static
           mv native_main native_main-armhf
           file native_main-armhf
         name: armhf build
@@ -48,13 +48,17 @@ jobs:
 
       - run: |
           sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
-          nimble build -d:release -d:danger --opt:speed -Y --cpu:arm64
+          nimble build -d:debug -Y --cpu:arm64 -l:static
           mv native_main native_main-arm64
           file native_main-arm64
         name: arm64 build
         if: runner.os == 'Linux'
 
       - run: nimble build -d:debug -Y --verbose
+        if: runner.os != 'Linux'
+
+      - run: nimble build -d:debug --verbose -l:static
+        if: runner.os == 'Linux'
 
       - run: |
           mv native_main.exe native_main

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Cache nimble
         id: cache-nimble
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.nimble
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -40,7 +40,7 @@ jobs:
 
       - run: |
           sudo apt-get install gcc-arm-linux-gnueabihf
-          nimble build -d:debug -Y --cpu:arm -l:static
+          nimble build -d:debug -Y --cpu:arm --passL:-static
           mv native_main native_main-armhf
           file native_main-armhf
         name: armhf build
@@ -48,7 +48,7 @@ jobs:
 
       - run: |
           sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
-          nimble build -d:debug -Y --cpu:arm64 -l:static
+          nimble build -d:debug -Y --cpu:arm64 --passL:-static
           mv native_main native_main-arm64
           file native_main-arm64
         name: arm64 build
@@ -57,7 +57,7 @@ jobs:
       - run: nimble build -d:debug -Y --verbose
         if: runner.os != 'Linux'
 
-      - run: nimble build -d:debug --verbose -l:static
+      - run: nimble build -d:debug --verbose --passL:-static
         if: runner.os == 'Linux'
 
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - run: |
           sudo apt-get install gcc-arm-linux-gnueabihf
-          nimble build -d:release -d:danger --opt:speed -Y --cpu:arm
+          nimble build -d:release -d:danger --opt:speed -Y --cpu:arm -l:static
           mv native_main native_main-armhf
           file native_main-armhf
         name: armhf build
@@ -74,13 +74,17 @@ jobs:
 
       - run: |
           sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
-          nimble build -d:release -d:danger --opt:speed -Y --cpu:arm64
+          nimble build -d:release -d:danger --opt:speed -Y --cpu:arm64 -l:static
           mv native_main native_main-arm64
           file native_main-arm64
         name: arm64 build
         if: runner.os == 'Linux'
 
       - run: nimble build -d:danger -d:release --opt:speed -Y --verbose
+        if: runner.os != 'Linux'
+
+      - run: nimble build -d:danger -d:release --opt:speed -Y --verbose -l:static
+        if: runner.os == 'Linux'
 
       - run: |
           mv native_main.exe native_main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - run: |
           sudo apt-get install gcc-arm-linux-gnueabihf
-          nimble build -d:release -d:danger --opt:speed -Y --cpu:arm -l:static
+          nimble build -d:release -d:danger --opt:speed -Y --cpu:arm --passL:-static
           mv native_main native_main-armhf
           file native_main-armhf
         name: armhf build
@@ -74,7 +74,7 @@ jobs:
 
       - run: |
           sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
-          nimble build -d:release -d:danger --opt:speed -Y --cpu:arm64 -l:static
+          nimble build -d:release -d:danger --opt:speed -Y --cpu:arm64 --passL:-static
           mv native_main native_main-arm64
           file native_main-arm64
         name: arm64 build
@@ -83,7 +83,7 @@ jobs:
       - run: nimble build -d:danger -d:release --opt:speed -Y --verbose
         if: runner.os != 'Linux'
 
-      - run: nimble build -d:danger -d:release --opt:speed -Y --verbose -l:static
+      - run: nimble build -d:danger -d:release --opt:speed -Y --verbose --passL:-static
         if: runner.os == 'Linux'
 
       - run: |

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -15,7 +15,7 @@ import tempfile
 when defined(windows):
     import windows_helpers
 
-const VERSION = "0.4.1"
+const VERSION = "0.5.0"
 
 type
     MessageRecv* = object


### PR DESCRIPTION
This should make them run on e.g. musl, fixes #50
