### PR TITLE
Add MVP connection-based communication

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -55,6 +55,8 @@ jobs:
       - run: nimble build -d:debug --verbose --passL:-static
         if: runner.os == 'Linux'
 
+      - run: nimble test -Y
+
       - run: |
           mv native_main.exe native_main
         shell: bash
@@ -67,8 +69,6 @@ jobs:
           lipo -create -output native_main native_main-x86 native_main-arm64
         if: runner.os == 'macOS'
 
-      # - run: nimble test -Y
-     
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ If more than one Firefox instance has opted in, the command reports their instan
 native_main --request 'reload' --instance 0123abcd
 ```
 
-The bridge binds an ephemeral port on `127.0.0.1`, i.e. not accessible on the local network. Each native instance publishes a random ID, port and high-entropy authentication token in its per-user cache directory. 
+The bridge binds an ephemeral port on `127.0.0.1`, i.e. not accessible on the local network. Each native instance publishes a random ID, port and high-entropy authentication token in its per-user cache directory.
 
 If you wish to reverse-engineer the protocol for doing stupid stuff like controlling Firefox across the network, you'l need to grab that token and forward the port.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This small application allows [Tridactyl](https://github.com/tridactyl/tridactyl
 - write files to your computer
 - launch applications, including opening `about:*` tabs in Firefox
 - and generally do arbitrary stuff in userspace.
+- from version 0.6.0 onwards, if `:set nativecontrol true` is set in the extension it can also send commands to Firefox.
 
 It therefore greatly increases the amount of damage bugs in Tridactyl can do to your machine, although, arguably, not to your life, since almost all of that is on the internet anyway. 
 
@@ -32,10 +33,35 @@ Three options:
 
 # Testing
 
-DIY testing:
+```
+nimble build
+nimble test
+```
+
+For manual compatibility testing:
 
 ```
 ./gen_native_message.py cmd..getconfigpath | ./native_main | cut -b4- | jq 'walk( if type == "object" then with_entries(select(.value != null)) else . end)'
 ```
 
 Swap `native_main` for the old `native_main.py` messenger to check compat.
+
+# Controlling Firefox via the messenger
+
+0.6.0+ supports sending an ex command to Firefox. First enable it in Tridactyl 1.26.0+ with `:set nativecontrol true`, then run:
+
+```
+~/.local/share/tridactyl/native_main --request 'tabopen https://example.com'
+```
+
+The default Windows path is `%USERPROFILE%\.tridactyl\native_main.exe`. If `XDG_DATA_HOME` is set, the Unix path is `$XDG_DATA_HOME/tridactyl/native_main`.
+
+If more than one Firefox instance has opted in, the command reports their instance IDs. Select one by full ID or a unique prefix:
+
+```
+native_main --request 'reload' --instance 0123abcd
+```
+
+The bridge binds an ephemeral port on `127.0.0.1`, i.e. not accessible on the local network. Each native instance publishes a random ID, port and high-entropy authentication token in its per-user cache directory. 
+
+If you wish to reverse-engineer the protocol for doing stupid stuff like controlling Firefox across the network, you'l need to grab that token and forward the port.

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,1 +1,2 @@
 d:debug
+--threads:on

--- a/src/control_bridge.nim
+++ b/src/control_bridge.nim
@@ -1,0 +1,782 @@
+import std/[algorithm, json, locks, monotimes, nativesockets, net, os, sequtils,
+  sha1, streams, strutils, sysrand, times]
+
+when defined(posix):
+    import std/posix
+when defined(windows):
+    import winlean
+
+const
+    CONTROL_PROTOCOL* = 1
+    CONTROL_CAPABILITY* = "control-port-v1"
+    MAX_CLI_FRAME* = 1024 * 1024
+    MAX_NATIVE_FRAME* = 64 * 1024 * 1024
+    AUTH_TIMEOUT_MS = 5_000
+    CONTROL_TIMEOUT_MS = 30_000
+    CLI_RESPONSE_TIMEOUT_MS = CONTROL_TIMEOUT_MS + 5_000
+    PROBE_TIMEOUT_MS = 250
+    MAX_CLIENTS = 32
+
+type
+    NativeFrameKind* = enum
+        nfkMessage, nfkEof, nfkInvalid
+
+    NativeFrame* = object
+        kind*: NativeFrameKind
+        payload*, error*: string
+
+    ControlStart* = object
+        ok*: bool
+        instance*, error*: string
+
+    StartupResult = object
+        ok: bool
+        port: int
+        instance, error: string
+
+    PendingSlot = object
+        active: bool
+        id: array[32, char]
+        replies: Channel[string]
+
+    WorkerArgs = object
+        socket: Socket
+        instance, token: string
+        index: int
+
+    SocketFrameKind = enum
+        sfkMessage, sfkEof, sfkInvalid
+
+    SocketFrame = object
+        kind: SocketFrameKind
+        payload, error: string
+
+    ServerAuth = enum
+        saAuthenticated, saUnavailable, saInvalid
+
+    DiscoveryRecord = object
+        path, instance, token: string
+        port, pid: int
+
+var
+    bridgeInitialized = false
+    nativeWriteLock, stateLock: Lock
+    startupChannel: Channel[StartupResult]
+    pendingSlots: array[MAX_CLIENTS, PendingSlot]
+    workerDone: array[MAX_CLIENTS, bool]
+    listenerThread: Thread[void]
+    listenerStarted, listenerExited, stopRequested: bool
+    stopIsDisconnect: bool
+    listenerPort: int
+    activeInstance: string
+
+func frameHeader(length: int): string =
+    let value = uint32(length)
+    result = newString(4)
+    result[0] = char(value and 0xff)
+    result[1] = char((value shr 8) and 0xff)
+    result[2] = char((value shr 16) and 0xff)
+    result[3] = char((value shr 24) and 0xff)
+
+func frameLength(header: string): uint32 =
+    uint32(header[0].ord) or
+      (uint32(header[1].ord) shl 8) or
+      (uint32(header[2].ord) shl 16) or
+      (uint32(header[3].ord) shl 24)
+
+proc nativeFrameHeader(length: int): string =
+    var value = uint32(length)
+    result = newString(sizeof(value))
+    copyMem(addr result[0], addr value, sizeof(value))
+
+proc nativeFrameLength(header: string): uint32 =
+    copyMem(addr result, unsafeAddr header[0], sizeof(result))
+
+proc readStreamExact(stream: Stream, size: int): tuple[ok, eof: bool,
+        data: string] =
+    result.data = newString(size)
+    var offset = 0
+    while offset < size:
+        let count = stream.readData(addr result.data[offset], size - offset)
+        if count == 0:
+            result.eof = offset == 0
+            result.data.setLen(offset)
+            return
+        offset += count
+    result.ok = true
+
+proc readNativeFrame*(stream: Stream): NativeFrame =
+    let header = readStreamExact(stream, 4)
+    if header.eof:
+        result.kind = nfkEof
+        return
+    if not header.ok:
+        result.kind = nfkInvalid
+        result.error = "truncated native message header"
+        return
+
+    let size = nativeFrameLength(header.data)
+    if size == 0:
+        result.kind = nfkEof
+    elif size > MAX_NATIVE_FRAME.uint32 or size.uint64 > high(int).uint64:
+        result.kind = nfkInvalid
+        result.error = "native message exceeds maximum frame length"
+    else:
+        let payload = readStreamExact(stream, size.int)
+        if payload.ok:
+            result.kind = nfkMessage
+            result.payload = payload.data
+        else:
+            result.kind = nfkInvalid
+            result.error = "truncated native message payload"
+
+proc writeNative*(payload: string): bool {.gcsafe.} =
+    if payload.len.uint64 > high(uint32).uint64:
+        stderr.writeLine("Native response exceeds the framing limit")
+        return false
+
+    let framed = nativeFrameHeader(payload.len) & payload
+    acquire(nativeWriteLock)
+    try:
+        let written = stdout.writeBuffer(unsafeAddr framed[0], framed.len)
+        flushFile(stdout)
+        result = written == framed.len
+    except IOError:
+        result = false
+    finally:
+        release(nativeWriteLock)
+
+proc initControlBridge*() =
+    if bridgeInitialized:
+        return
+    initLock(nativeWriteLock)
+    initLock(stateLock)
+    startupChannel.open()
+    for slot in pendingSlots.mitems:
+        slot.replies.open()
+    bridgeInitialized = true
+
+proc randomHex(byteCount: int): string =
+    const digits = "0123456789abcdef"
+    var bytes = newSeq[byte](byteCount)
+    if not urandom(bytes):
+        raise newException(OSError, "secure random number generation failed")
+    result = newString(byteCount * 2)
+    for index, value in bytes:
+        result[index * 2] = digits[int(value shr 4)]
+        result[index * 2 + 1] = digits[int(value and 0x0f)]
+
+func constantTimeEqual(left, right: string): bool =
+    if left.len != right.len:
+        return false
+    var difference = 0
+    for index in 0 ..< left.len:
+        difference = difference or (left[index].ord xor right[index].ord)
+    difference == 0
+
+func isHex(value: string, length: int): bool =
+    if value.len != length:
+        return false
+    for character in value:
+        if character notin {'0'..'9', 'a'..'f'}:
+            return false
+    true
+
+proc discoveryDirectory(): string =
+    getCacheDir() / "tridactyl" / "native-control"
+
+proc removeRecord(path: string) =
+    if path.len == 0:
+        return
+    try:
+        if fileExists(path):
+            removeFile(path)
+    except OSError:
+        discard
+
+proc processMayExist(pid: int): bool =
+    if pid <= 0:
+        return false
+    when defined(posix):
+        result = kill(Pid(pid), 0) == 0 or errno == EPERM
+    elif defined(windows):
+        let process = openProcess(DWORD(PROCESS_QUERY_LIMITED_INFORMATION), 0,
+          DWORD(pid))
+        if process != 0:
+            discard closeHandle(process)
+            result = true
+        else:
+            result = getLastError() != 87 # ERROR_INVALID_PARAMETER
+    else:
+        result = true
+
+proc removeRecordIfDead(record: DiscoveryRecord) =
+    if not processMayExist(record.pid):
+        removeRecord(record.path)
+
+proc publishRecord(instance, token: string, port: int): string =
+    when defined(posix):
+        let previousMask = umask(Mode(0o077))
+        defer: discard umask(previousMask)
+
+    let directory = discoveryDirectory()
+    createDir(directory)
+    when defined(posix):
+        setFilePermissions(directory, {fpUserRead, fpUserWrite, fpUserExec})
+
+    result = directory / (instance & ".json")
+    let temporary = result & ".tmp"
+    let record = %*{
+        "protocol": CONTROL_PROTOCOL,
+        "instance": instance,
+        "port": port,
+        "token": token,
+        "pid": getCurrentProcessId()
+    }
+    try:
+        writeFile(temporary, $record)
+        when defined(posix):
+            setFilePermissions(temporary, {fpUserRead, fpUserWrite})
+        moveFile(temporary, result)
+    except:
+        removeRecord(temporary)
+        removeRecord(result)
+        raise
+
+proc remainingTimeout(started: MonoTime, timeout: int): int =
+    timeout - int((getMonoTime() - started).inMilliseconds)
+
+proc shouldStop(): tuple[stop, disconnected: bool] =
+    acquire(stateLock)
+    result = (stopRequested, stopIsDisconnect)
+    release(stateLock)
+
+proc recvExact(socket: Socket, size, timeout: int,
+        stopAware: bool): tuple[ok, eof: bool, data, error: string] =
+    result.data = newStringOfCap(size)
+    let started = getMonoTime()
+    while result.data.len < size:
+        if stopAware and shouldStop().stop:
+            result.eof = true
+            return
+        let remaining = remainingTimeout(started, timeout)
+        if remaining <= 0:
+            result.error = "request timed out"
+            return
+        try:
+            let receiveTimeout = if stopAware: min(remaining, 100) else: remaining
+            let chunk = socket.recv(size - result.data.len, receiveTimeout)
+            if chunk.len == 0:
+                result.eof = result.data.len == 0
+                if not result.eof:
+                    result.error = "truncated frame"
+                return
+            result.data.add(chunk)
+        except TimeoutError:
+            if not stopAware:
+                result.error = "request timed out"
+                return
+        except OSError:
+            result.error = "connection closed"
+            return
+    result.ok = true
+
+proc recvSocketFrame(socket: Socket, timeout: int,
+        stopAware = false): SocketFrame =
+    let header = recvExact(socket, 4, timeout, stopAware)
+    if header.eof:
+        result.kind = sfkEof
+        return
+    if not header.ok:
+        result.kind = sfkInvalid
+        result.error = header.error
+        return
+
+    let size = frameLength(header.data)
+    if size == 0 or size > MAX_CLI_FRAME.uint32:
+        result.kind = sfkInvalid
+        result.error = "invalid frame length"
+        return
+
+    let payload = recvExact(socket, size.int, timeout, stopAware)
+    if payload.ok:
+        result.kind = sfkMessage
+        result.payload = payload.data
+    else:
+        result.kind = sfkInvalid
+        result.error = payload.error
+
+proc sendSocketFrame(socket: Socket, payload: string) =
+    if payload.len > MAX_CLI_FRAME:
+        raise newException(ValueError, "response exceeds maximum frame length")
+    let framed = frameHeader(payload.len) & payload
+    let descriptor = socket.getFd()
+    descriptor.setBlocking(false)
+    defer:
+        try:
+            descriptor.setBlocking(true)
+        except OSError:
+            discard
+
+    let started = getMonoTime()
+    var offset = 0
+    while offset < framed.len:
+        if remainingTimeout(started, AUTH_TIMEOUT_MS) <= 0:
+            raise newException(TimeoutError, "response timed out")
+        let sent = socket.send(unsafeAddr framed[offset], framed.len - offset)
+        if sent > 0:
+            offset += sent
+        elif sent == 0:
+            raise newException(IOError, "connection closed")
+        else:
+            let error = osLastError()
+            let retryable =
+                when defined(windows):
+                    error.int32 in [WSAEINTR, WSAEWOULDBLOCK]
+                else:
+                    error.int32 in [EINTR, EWOULDBLOCK, EAGAIN]
+            if not retryable:
+                raiseOSError(error)
+            sleep(1)
+
+func errorResponse(message: string): string =
+    $(%*{"protocol": CONTROL_PROTOCOL, "ok": false, "error": message})
+
+proc setPending(index: int, id: string) =
+    acquire(stateLock)
+    while pendingSlots[index].replies.tryRecv().dataAvailable:
+        discard
+    pendingSlots[index].active = true
+    for idIndex in 0 ..< pendingSlots[index].id.len:
+        pendingSlots[index].id[idIndex] = id[idIndex]
+    release(stateLock)
+
+proc clearPending(index: int, id: string) =
+    acquire(stateLock)
+    if pendingSlots[index].active:
+        var matches = id.len == pendingSlots[index].id.len
+        for idIndex in 0 ..< pendingSlots[index].id.len:
+            matches = matches and pendingSlots[index].id[idIndex] == id[idIndex]
+        if matches:
+            pendingSlots[index].active = false
+    release(stateLock)
+
+proc waitForExtension(index: int): string =
+    let started = getMonoTime()
+    while remainingTimeout(started, CONTROL_TIMEOUT_MS) > 0:
+        let stopping = shouldStop()
+        if stopping.stop:
+            if stopping.disconnected:
+                return errorResponse("extension disconnected")
+            return errorResponse("control endpoint disabled")
+
+        let received = pendingSlots[index].replies.tryRecv()
+        if received.dataAvailable:
+            return received.msg
+        sleep(10)
+    errorResponse("extension response timed out")
+
+func controlProof(token, challenge: string): string =
+    $secureHash(token & challenge)
+
+proc validCliRequest(node: JsonNode, token: string): bool =
+    node.kind == JObject and
+      node.hasKey("protocol") and node["protocol"].kind == JInt and
+      node["protocol"].getBiggestInt == CONTROL_PROTOCOL and
+      node.hasKey("token") and node["token"].kind == JString and
+      constantTimeEqual(node["token"].getStr, token) and
+      node.hasKey("operation") and node["operation"].kind == JString and
+      node["operation"].getStr == "ex" and
+      node.hasKey("command") and node["command"].kind == JString
+
+proc handleClient(socket: Socket, instance, token: string, index: int) =
+    let challengeFrame = recvSocketFrame(socket, AUTH_TIMEOUT_MS,
+      stopAware = true)
+    if challengeFrame.kind == sfkEof:
+        return
+    if challengeFrame.kind == sfkInvalid:
+        sendSocketFrame(socket, errorResponse(challengeFrame.error))
+        return
+
+    var challenge: JsonNode
+    try:
+        challenge = parseJson(challengeFrame.payload)
+    except JsonParsingError:
+        sendSocketFrame(socket, errorResponse("invalid challenge"))
+        return
+    if challenge.kind != JObject or
+      not challenge.hasKey("protocol") or challenge["protocol"].kind != JInt or
+      challenge["protocol"].getBiggestInt != CONTROL_PROTOCOL or
+      not challenge.hasKey("challenge") or challenge["challenge"].kind != JString or
+      not isHex(challenge["challenge"].getStr, 32):
+        sendSocketFrame(socket, errorResponse("invalid challenge"))
+        return
+    sendSocketFrame(socket, $(%*{
+        "protocol": CONTROL_PROTOCOL,
+        "instance": instance,
+        "proof": controlProof(token, challenge["challenge"].getStr)
+    }))
+
+    let incoming = recvSocketFrame(socket, AUTH_TIMEOUT_MS, stopAware = true)
+    if incoming.kind == sfkEof:
+        return
+    if incoming.kind == sfkInvalid:
+        sendSocketFrame(socket, errorResponse(incoming.error))
+        return
+
+    var request: JsonNode
+    try:
+        request = parseJson(incoming.payload)
+    except JsonParsingError:
+        sendSocketFrame(socket, errorResponse("invalid request"))
+        return
+    if not validCliRequest(request, token):
+        sendSocketFrame(socket, errorResponse("authentication failed"))
+        return
+
+    let id = randomHex(16)
+    let nativeRequest = %*{
+        "type": "control.request",
+        "protocol": CONTROL_PROTOCOL,
+        "id": id,
+        "operation": "ex",
+        "command": request["command"].getStr
+    }
+    setPending(index, id)
+    defer: clearPending(index, id)
+    if not writeNative($nativeRequest):
+        sendSocketFrame(socket, errorResponse("extension disconnected"))
+        return
+    sendSocketFrame(socket, waitForExtension(index))
+
+proc clientMain(arguments: WorkerArgs) {.thread.} =
+    try:
+        handleClient(arguments.socket, arguments.instance, arguments.token,
+          arguments.index)
+    except CatchableError:
+        try:
+            sendSocketFrame(arguments.socket, errorResponse("control request failed"))
+        except CatchableError:
+            discard
+    finally:
+        arguments.socket.close()
+        acquire(stateLock)
+        workerDone[arguments.index] = true
+        release(stateLock)
+
+proc listenerMain() {.thread.} =
+    var
+        server: Socket
+        recordPath = ""
+        announced = false
+        workers: array[MAX_CLIENTS, Thread[WorkerArgs]]
+        workerUsed: array[MAX_CLIENTS, bool]
+    try:
+        let token = randomHex(32)
+        let instance = randomHex(16)
+        server = newSocket(buffered = false)
+        server.bindAddr(Port(0), "127.0.0.1")
+        server.listen()
+        let (_, boundPort) = server.getLocalAddr()
+        let port = boundPort.int
+        recordPath = publishRecord(instance, token, port)
+        startupChannel.send(StartupResult(ok: true, port: port,
+          instance: instance))
+        announced = true
+
+        while not shouldStop().stop:
+            var client: Socket
+            server.accept(client)
+            if shouldStop().stop:
+                client.close()
+                break
+
+            for index in 0 ..< MAX_CLIENTS:
+                if workerUsed[index]:
+                    acquire(stateLock)
+                    let done = workerDone[index]
+                    release(stateLock)
+                    if done:
+                        joinThread(workers[index])
+                        workerUsed[index] = false
+
+            var workerIndex = -1
+            for index in 0 ..< MAX_CLIENTS:
+                if not workerUsed[index]:
+                    workerIndex = index
+                    break
+            if workerIndex < 0:
+                client.close()
+                continue
+
+            acquire(stateLock)
+            workerDone[workerIndex] = false
+            release(stateLock)
+            try:
+                createThread(workers[workerIndex], clientMain,
+                  WorkerArgs(socket: client, instance: instance, token: token,
+                    index: workerIndex))
+                workerUsed[workerIndex] = true
+            except CatchableError:
+                client.close()
+    except CatchableError:
+        if not announced:
+            startupChannel.send(StartupResult(ok: false,
+              error: "could not start the control endpoint"))
+        else:
+            stderr.writeLine("Control endpoint stopped unexpectedly")
+    finally:
+        acquire(stateLock)
+        stopRequested = true
+        release(stateLock)
+        if server != nil:
+            server.close()
+        removeRecord(recordPath)
+        for index in 0 ..< MAX_CLIENTS:
+            if workerUsed[index]:
+                joinThread(workers[index])
+        acquire(stateLock)
+        listenerExited = true
+        release(stateLock)
+
+proc listenerHasExited(): bool =
+    acquire(stateLock)
+    result = listenerExited
+    release(stateLock)
+
+proc startControl*(): ControlStart =
+    if listenerStarted and not listenerHasExited():
+        return ControlStart(ok: true, instance: activeInstance)
+    if listenerStarted:
+        joinThread(listenerThread)
+        listenerStarted = false
+
+    acquire(stateLock)
+    stopRequested = false
+    stopIsDisconnect = false
+    listenerExited = false
+    release(stateLock)
+    try:
+        createThread(listenerThread, listenerMain)
+        listenerStarted = true
+    except CatchableError:
+        return ControlStart(error: "could not create the control thread")
+
+    let startup = startupChannel.recv()
+    if not startup.ok:
+        joinThread(listenerThread)
+        listenerStarted = false
+        return ControlStart(error: startup.error)
+
+    listenerPort = startup.port
+    activeInstance = startup.instance
+    ControlStart(ok: true, instance: startup.instance)
+
+proc wakeListener(port: int) =
+    if port == 0:
+        return
+    var socket: Socket
+    try:
+        socket = newSocket(buffered = false)
+        socket.connect("127.0.0.1", Port(port), timeout = PROBE_TIMEOUT_MS)
+    except CatchableError:
+        discard
+    finally:
+        if socket != nil:
+            socket.close()
+
+proc stopControl*(extensionDisconnected = false) =
+    if not listenerStarted:
+        return
+    acquire(stateLock)
+    stopRequested = true
+    stopIsDisconnect = extensionDisconnected
+    release(stateLock)
+    wakeListener(listenerPort)
+    joinThread(listenerThread)
+    listenerStarted = false
+    listenerPort = 0
+    activeInstance = ""
+
+proc deliverControlResponse*(id, payload: string): bool =
+    if id.len != pendingSlots[0].id.len:
+        return false
+    acquire(stateLock)
+    var selected = -1
+    for index in 0 ..< MAX_CLIENTS:
+        var matches = pendingSlots[index].active
+        for idIndex in 0 ..< pendingSlots[index].id.len:
+            matches = matches and pendingSlots[index].id[idIndex] == id[idIndex]
+        if matches:
+            selected = index
+            break
+    if selected >= 0:
+        pendingSlots[selected].replies.send(payload)
+        result = true
+    release(stateLock)
+
+proc loadRecords(): seq[DiscoveryRecord] =
+    let directory = discoveryDirectory()
+    if not dirExists(directory):
+        return
+    for path in walkFiles(directory / "*.json"):
+        try:
+            let node = parseFile(path)
+            if node.kind != JObject or
+              not node.hasKey("protocol") or node["protocol"].kind != JInt or
+              node["protocol"].getBiggestInt != CONTROL_PROTOCOL or
+              not node.hasKey("instance") or node["instance"].kind != JString or
+              not node.hasKey("token") or node["token"].kind != JString or
+              not node.hasKey("port") or node["port"].kind != JInt or
+              not node.hasKey("pid") or node["pid"].kind != JInt:
+                raise newException(ValueError, "invalid discovery record")
+            let port = node["port"].getBiggestInt
+            let pid = node["pid"].getBiggestInt
+            if port < 1 or port > 65_535 or pid < 1 or
+              pid > BiggestInt(high(int32)):
+                raise newException(ValueError, "invalid discovery record")
+            let record = DiscoveryRecord(
+                path: path,
+                instance: node["instance"].getStr,
+                token: node["token"].getStr,
+                port: port.int,
+                pid: pid.int,
+            )
+            if not isHex(record.instance, 32) or not isHex(record.token, 64) or
+              path.extractFilename != record.instance & ".json":
+                raise newException(ValueError, "invalid discovery record")
+            result.add(record)
+        except CatchableError:
+            removeRecord(path)
+
+proc authenticateServer(socket: Socket, record: DiscoveryRecord,
+        timeout = AUTH_TIMEOUT_MS): ServerAuth =
+    let challenge = randomHex(16)
+    try:
+        sendSocketFrame(socket, $(%*{
+            "protocol": CONTROL_PROTOCOL,
+            "challenge": challenge
+        }))
+    except CatchableError:
+        return saUnavailable
+    let responseFrame = recvSocketFrame(socket, timeout)
+    if responseFrame.kind == sfkEof:
+        return saUnavailable
+    if responseFrame.kind != sfkMessage:
+        return saUnavailable
+    var response: JsonNode
+    try:
+        response = parseJson(responseFrame.payload)
+    except JsonParsingError:
+        return saInvalid
+    if response.kind == JObject and
+      response.hasKey("protocol") and response["protocol"].kind == JInt and
+      response["protocol"].getBiggestInt == CONTROL_PROTOCOL and
+      response.hasKey("instance") and response["instance"].kind == JString and
+      response["instance"].getStr == record.instance and
+      response.hasKey("proof") and response["proof"].kind == JString and
+      constantTimeEqual(response["proof"].getStr,
+        controlProof(record.token, challenge)):
+        saAuthenticated
+    else:
+        saInvalid
+
+proc canConnect(record: DiscoveryRecord): bool =
+    var socket: Socket
+    try:
+        socket = newSocket(buffered = false)
+        socket.connect("127.0.0.1", Port(record.port), timeout = PROBE_TIMEOUT_MS)
+        let authenticated = authenticateServer(socket, record,
+          PROBE_TIMEOUT_MS)
+        result = authenticated == saAuthenticated
+        if authenticated == saInvalid:
+            removeRecord(record.path)
+        elif authenticated == saUnavailable:
+            removeRecordIfDead(record)
+    except CatchableError:
+        removeRecordIfDead(record)
+    finally:
+        if socket != nil:
+            socket.close()
+
+proc liveRecords(records: seq[DiscoveryRecord]): seq[DiscoveryRecord] =
+    for record in records:
+        if canConnect(record):
+            result.add(record)
+    result.sort(proc(left, right: DiscoveryRecord): int =
+      cmp(left.instance, right.instance))
+
+proc chooseRecord(selector: string): tuple[ok: bool, record: DiscoveryRecord,
+        error: string] =
+    var records = loadRecords()
+    if selector.len > 0:
+        records = records.filterIt(it.instance.startsWith(selector))
+    records = liveRecords(records)
+    if selector.len > 0:
+        if records.len == 0:
+            return (false, DiscoveryRecord(), "no native host matches instance " & selector)
+        if records.len > 1:
+            return (false, DiscoveryRecord(), "instance selector is ambiguous")
+    elif records.len == 0:
+        return (false, DiscoveryRecord(), "no opted-in native host found")
+    elif records.len > 1:
+        var instances: seq[string]
+        for record in records:
+            instances.add(record.instance)
+        return (false, DiscoveryRecord(),
+          "multiple opted-in native hosts found; use --instance with one of: " &
+          instances.join(", "))
+    (true, records[0], "")
+
+proc runCli*(command, selector: string): int =
+    let selected = chooseRecord(selector)
+    if not selected.ok:
+        stderr.writeLine(selected.error)
+        return 1
+
+    var socket: Socket
+    try:
+        socket = newSocket(buffered = false)
+        socket.connect("127.0.0.1", Port(selected.record.port),
+          timeout = PROBE_TIMEOUT_MS)
+        if authenticateServer(socket, selected.record) != saAuthenticated:
+            stderr.writeLine("selected native host failed authentication")
+            return 1
+        let request = %*{
+            "protocol": CONTROL_PROTOCOL,
+            "token": selected.record.token,
+            "operation": "ex",
+            "command": command
+        }
+        sendSocketFrame(socket, $request)
+        let responseFrame = recvSocketFrame(socket, CLI_RESPONSE_TIMEOUT_MS)
+        if responseFrame.kind != sfkMessage:
+            stderr.writeLine(if responseFrame.error.len > 0:
+              responseFrame.error else: "control connection closed")
+            return 1
+
+        let response = parseJson(responseFrame.payload)
+        if response.kind != JObject or
+          not response.hasKey("protocol") or response["protocol"].kind != JInt or
+          response["protocol"].getBiggestInt != CONTROL_PROTOCOL or
+          not response.hasKey("ok") or response["ok"].kind != JBool:
+            stderr.writeLine("invalid control response")
+            return 1
+        if not response["ok"].getBool:
+            if response.hasKey("error") and response["error"].kind == JString:
+                stderr.writeLine(response["error"].getStr)
+            else:
+                stderr.writeLine("control request failed")
+            return 1
+        if response.hasKey("result"):
+            if response["result"].kind == JString:
+                stdout.writeLine(response["result"].getStr)
+            else:
+                stdout.writeLine($response["result"])
+        result = 0
+    except CatchableError:
+        stderr.writeLine("could not contact the selected native host")
+        result = 1
+    finally:
+        if socket != nil:
+            socket.close()

--- a/src/control_bridge.nim
+++ b/src/control_bridge.nim
@@ -1,5 +1,5 @@
 import std/[algorithm, json, locks, monotimes, nativesockets, net, os, sequtils,
-  sha1, streams, strutils, sysrand, times]
+  strutils, sysrand, times]
 
 when defined(posix):
     import std/posix
@@ -9,149 +9,73 @@ when defined(windows):
 const
     CONTROL_PROTOCOL* = 1
     CONTROL_CAPABILITY* = "control-port-v1"
-    MAX_CLI_FRAME* = 1024 * 1024
-    MAX_NATIVE_FRAME* = 64 * 1024 * 1024
-    AUTH_TIMEOUT_MS = 5_000
+    MAX_CLI_LINE = 1024 * 1024
+    CLIENT_TIMEOUT_MS = 1_000
     CONTROL_TIMEOUT_MS = 30_000
     CLI_RESPONSE_TIMEOUT_MS = CONTROL_TIMEOUT_MS + 5_000
     PROBE_TIMEOUT_MS = 250
     MAX_CLIENTS = 32
 
 type
-    NativeFrameKind* = enum
-        nfkMessage, nfkEof, nfkInvalid
-
-    NativeFrame* = object
-        kind*: NativeFrameKind
-        payload*, error*: string
-
     ControlStart* = object
         ok*: bool
         instance*, error*: string
 
-    StartupResult = object
-        ok: bool
-        port: int
-        instance, error: string
+    WorkerArgs = object
+        socket: Socket
+        token: string
+        index: int
+
+    ListenerArgs = object
+        server: Socket
+        recordPath, token: string
 
     PendingSlot = object
         active: bool
         id: array[32, char]
         replies: Channel[string]
 
-    WorkerArgs = object
-        socket: Socket
-        instance, token: string
-        index: int
-
-    SocketFrameKind = enum
-        sfkMessage, sfkEof, sfkInvalid
-
-    SocketFrame = object
-        kind: SocketFrameKind
-        payload, error: string
-
-    ServerAuth = enum
-        saAuthenticated, saUnavailable, saInvalid
-
     DiscoveryRecord = object
         path, instance, token: string
-        port, pid: int
+        port: int
+        pid: BiggestInt
+
+    DiscoveryData = object
+        protocol, port, pid: BiggestInt
+        instance, token: string
 
 var
     bridgeInitialized = false
     nativeWriteLock, stateLock: Lock
-    startupChannel: Channel[StartupResult]
     pendingSlots: array[MAX_CLIENTS, PendingSlot]
-    workerDone: array[MAX_CLIENTS, bool]
-    listenerThread: Thread[void]
-    listenerStarted, listenerExited, stopRequested: bool
-    stopIsDisconnect: bool
+    completedWorkers: Channel[int]
+    listenerThread: Thread[ListenerArgs]
+    listenerStarted, listenerExited, stopRequested, stopIsDisconnect: bool
     listenerPort: int
     activeInstance: string
-
-func frameHeader(length: int): string =
-    let value = uint32(length)
-    result = newString(4)
-    result[0] = char(value and 0xff)
-    result[1] = char((value shr 8) and 0xff)
-    result[2] = char((value shr 16) and 0xff)
-    result[3] = char((value shr 24) and 0xff)
-
-func frameLength(header: string): uint32 =
-    uint32(header[0].ord) or
-      (uint32(header[1].ord) shl 8) or
-      (uint32(header[2].ord) shl 16) or
-      (uint32(header[3].ord) shl 24)
-
-proc nativeFrameHeader(length: int): string =
-    var value = uint32(length)
-    result = newString(sizeof(value))
-    copyMem(addr result[0], addr value, sizeof(value))
-
-proc nativeFrameLength(header: string): uint32 =
-    copyMem(addr result, unsafeAddr header[0], sizeof(result))
-
-proc readStreamExact(stream: Stream, size: int): tuple[ok, eof: bool,
-        data: string] =
-    result.data = newString(size)
-    var offset = 0
-    while offset < size:
-        let count = stream.readData(addr result.data[offset], size - offset)
-        if count == 0:
-            result.eof = offset == 0
-            result.data.setLen(offset)
-            return
-        offset += count
-    result.ok = true
-
-proc readNativeFrame*(stream: Stream): NativeFrame =
-    let header = readStreamExact(stream, 4)
-    if header.eof:
-        result.kind = nfkEof
-        return
-    if not header.ok:
-        result.kind = nfkInvalid
-        result.error = "truncated native message header"
-        return
-
-    let size = nativeFrameLength(header.data)
-    if size == 0:
-        result.kind = nfkEof
-    elif size > MAX_NATIVE_FRAME.uint32 or size.uint64 > high(int).uint64:
-        result.kind = nfkInvalid
-        result.error = "native message exceeds maximum frame length"
-    else:
-        let payload = readStreamExact(stream, size.int)
-        if payload.ok:
-            result.kind = nfkMessage
-            result.payload = payload.data
-        else:
-            result.kind = nfkInvalid
-            result.error = "truncated native message payload"
 
 proc writeNative*(payload: string): bool {.gcsafe.} =
     if payload.len.uint64 > high(uint32).uint64:
         stderr.writeLine("Native response exceeds the framing limit")
         return false
 
-    let framed = nativeFrameHeader(payload.len) & payload
-    acquire(nativeWriteLock)
-    try:
-        let written = stdout.writeBuffer(unsafeAddr framed[0], framed.len)
-        flushFile(stdout)
-        result = written == framed.len
-    except IOError:
-        result = false
-    finally:
-        release(nativeWriteLock)
+    var size = payload.len.uint32
+    withLock nativeWriteLock:
+        try:
+            result = stdout.writeBuffer(addr size, sizeof(size)) == sizeof(size)
+            if result and payload.len > 0:
+                result = stdout.writeBuffer(unsafeAddr payload[0], payload.len) ==
+                  payload.len
+            flushFile(stdout)
+        except IOError:
+            result = false
 
 proc initControlBridge*() =
     if bridgeInitialized:
         return
     initLock(nativeWriteLock)
     initLock(stateLock)
-    startupChannel.open()
+    completedWorkers.open()
     for slot in pendingSlots.mitems:
         slot.replies.open()
     bridgeInitialized = true
@@ -166,6 +90,9 @@ proc randomHex(byteCount: int): string =
         result[index * 2] = digits[int(value shr 4)]
         result[index * 2 + 1] = digits[int(value and 0x0f)]
 
+func isHex(value: string, length: int): bool =
+    value.len == length and value.allCharsInSet({'0'..'9', 'a'..'f'})
+
 func constantTimeEqual(left, right: string): bool =
     if left.len != right.len:
         return false
@@ -174,27 +101,17 @@ func constantTimeEqual(left, right: string): bool =
         difference = difference or (left[index].ord xor right[index].ord)
     difference == 0
 
-func isHex(value: string, length: int): bool =
-    if value.len != length:
-        return false
-    for character in value:
-        if character notin {'0'..'9', 'a'..'f'}:
-            return false
-    true
-
 proc discoveryDirectory(): string =
     getCacheDir() / "tridactyl" / "native-control"
 
 proc removeRecord(path: string) =
-    if path.len == 0:
-        return
     try:
-        if fileExists(path):
+        if path.len > 0 and fileExists(path):
             removeFile(path)
     except OSError:
         discard
 
-proc processMayExist(pid: int): bool =
+proc processMayExist(pid: BiggestInt): bool =
     if pid <= 0:
         return false
     when defined(posix):
@@ -226,15 +143,14 @@ proc publishRecord(instance, token: string, port: int): string =
 
     result = directory / (instance & ".json")
     let temporary = result & ".tmp"
-    let record = %*{
-        "protocol": CONTROL_PROTOCOL,
-        "instance": instance,
-        "port": port,
-        "token": token,
-        "pid": getCurrentProcessId()
-    }
     try:
-        writeFile(temporary, $record)
+        writeFile(temporary, $(%*{
+            "protocol": CONTROL_PROTOCOL,
+            "instance": instance,
+            "port": port,
+            "token": token,
+            "pid": getCurrentProcessId()
+        }))
         when defined(posix):
             setFilePermissions(temporary, {fpUserRead, fpUserWrite})
         moveFile(temporary, result)
@@ -246,84 +162,33 @@ proc publishRecord(instance, token: string, port: int): string =
 proc remainingTimeout(started: MonoTime, timeout: int): int =
     timeout - int((getMonoTime() - started).inMilliseconds)
 
-proc shouldStop(): tuple[stop, disconnected: bool] =
-    acquire(stateLock)
-    result = (stopRequested, stopIsDisconnect)
-    release(stateLock)
+proc stopping(): tuple[stop, disconnected: bool] =
+    withLock stateLock:
+        result = (stopRequested, stopIsDisconnect)
 
-proc recvExact(socket: Socket, size, timeout: int,
-        stopAware: bool): tuple[ok, eof: bool, data, error: string] =
-    result.data = newStringOfCap(size)
-    let started = getMonoTime()
-    while result.data.len < size:
-        if stopAware and shouldStop().stop:
-            result.eof = true
-            return
-        let remaining = remainingTimeout(started, timeout)
-        if remaining <= 0:
-            result.error = "request timed out"
-            return
-        try:
-            let receiveTimeout = if stopAware: min(remaining, 100) else: remaining
-            let chunk = socket.recv(size - result.data.len, receiveTimeout)
-            if chunk.len == 0:
-                result.eof = result.data.len == 0
-                if not result.eof:
-                    result.error = "truncated frame"
-                return
-            result.data.add(chunk)
-        except TimeoutError:
-            if not stopAware:
-                result.error = "request timed out"
-                return
-        except OSError:
-            result.error = "connection closed"
-            return
-    result.ok = true
+proc errorResponse(message: string): string =
+    $(%*{"protocol": CONTROL_PROTOCOL, "ok": false, "error": message})
 
-proc recvSocketFrame(socket: Socket, timeout: int,
-        stopAware = false): SocketFrame =
-    let header = recvExact(socket, 4, timeout, stopAware)
-    if header.eof:
-        result.kind = sfkEof
-        return
-    if not header.ok:
-        result.kind = sfkInvalid
-        result.error = header.error
-        return
+func validProtocol(node: JsonNode): bool =
+    node.kind == JObject and
+      node{"protocol"}.getBiggestInt(-1) == CONTROL_PROTOCOL
 
-    let size = frameLength(header.data)
-    if size == 0 or size > MAX_CLI_FRAME.uint32:
-        result.kind = sfkInvalid
-        result.error = "invalid frame length"
-        return
-
-    let payload = recvExact(socket, size.int, timeout, stopAware)
-    if payload.ok:
-        result.kind = sfkMessage
-        result.payload = payload.data
-    else:
-        result.kind = sfkInvalid
-        result.error = payload.error
-
-proc sendSocketFrame(socket: Socket, payload: string) =
-    if payload.len > MAX_CLI_FRAME:
-        raise newException(ValueError, "response exceeds maximum frame length")
-    let framed = frameHeader(payload.len) & payload
-    let descriptor = socket.getFd()
+proc sendLine(socket: Socket, payload: string) =
+    if payload.len > MAX_CLI_LINE:
+        raise newException(ValueError, "response exceeds maximum line length")
+    let
+        data = payload & "\n"
+        descriptor = socket.getFd()
+        started = getMonoTime()
     descriptor.setBlocking(false)
     defer:
         try:
             descriptor.setBlocking(true)
         except OSError:
             discard
-
-    let started = getMonoTime()
     var offset = 0
-    while offset < framed.len:
-        if remainingTimeout(started, AUTH_TIMEOUT_MS) <= 0:
-            raise newException(TimeoutError, "response timed out")
-        let sent = socket.send(unsafeAddr framed[offset], framed.len - offset)
+    while offset < data.len:
+        let sent = socket.send(unsafeAddr data[offset], data.len - offset)
         if sent > 0:
             offset += sent
         elif sent == 0:
@@ -331,218 +196,136 @@ proc sendSocketFrame(socket: Socket, payload: string) =
         else:
             let error = osLastError()
             let retryable =
-                when defined(windows):
-                    error.int32 in [WSAEINTR, WSAEWOULDBLOCK]
-                else:
-                    error.int32 in [EINTR, EWOULDBLOCK, EAGAIN]
+                when defined(windows): error.int32 in [WSAEINTR, WSAEWOULDBLOCK]
+                else: error.int32 in [EINTR, EWOULDBLOCK, EAGAIN]
             if not retryable:
                 raiseOSError(error)
+            if remainingTimeout(started, CLIENT_TIMEOUT_MS) <= 0:
+                raise newException(TimeoutError, "response timed out")
             sleep(1)
 
-func errorResponse(message: string): string =
-    $(%*{"protocol": CONTROL_PROTOCOL, "ok": false, "error": message})
+proc receiveJson(socket: Socket, timeout: int): JsonNode =
+    let line = socket.recvLine(timeout = timeout, maxLength = MAX_CLI_LINE)
+    if line.len == 0:
+        raise newException(IOError, "connection closed")
+    if line.len > MAX_CLI_LINE:
+        raise newException(ValueError, "request exceeds maximum line length")
+    parseJson(line)
 
 proc setPending(index: int, id: string) =
-    acquire(stateLock)
     while pendingSlots[index].replies.tryRecv().dataAvailable:
         discard
-    pendingSlots[index].active = true
-    for idIndex in 0 ..< pendingSlots[index].id.len:
-        pendingSlots[index].id[idIndex] = id[idIndex]
-    release(stateLock)
+    withLock stateLock:
+        pendingSlots[index].active = true
+        for offset, character in id:
+            pendingSlots[index].id[offset] = character
 
-proc clearPending(index: int, id: string) =
-    acquire(stateLock)
-    if pendingSlots[index].active:
-        var matches = id.len == pendingSlots[index].id.len
-        for idIndex in 0 ..< pendingSlots[index].id.len:
-            matches = matches and pendingSlots[index].id[idIndex] == id[idIndex]
-        if matches:
-            pendingSlots[index].active = false
-    release(stateLock)
+proc clearPending(index: int) =
+    withLock stateLock:
+        pendingSlots[index].active = false
 
 proc waitForExtension(index: int): string =
     let started = getMonoTime()
     while remainingTimeout(started, CONTROL_TIMEOUT_MS) > 0:
-        let stopping = shouldStop()
-        if stopping.stop:
-            if stopping.disconnected:
-                return errorResponse("extension disconnected")
-            return errorResponse("control endpoint disabled")
-
+        let state = stopping()
+        if state.stop:
+            return errorResponse(if state.disconnected: "extension disconnected"
+              else: "control endpoint disabled")
         let received = pendingSlots[index].replies.tryRecv()
         if received.dataAvailable:
             return received.msg
         sleep(10)
-    errorResponse("extension response timed out")
+    result = errorResponse("extension response timed out")
 
-func controlProof(token, challenge: string): string =
-    $secureHash(token & challenge)
+proc validRequest(node: JsonNode, token: string): bool =
+    validProtocol(node) and constantTimeEqual(node{"token"}.getStr, token) and
+      node{"operation"}.getStr == "ex" and node{"command"}.getStr.len > 0
 
-proc validCliRequest(node: JsonNode, token: string): bool =
-    node.kind == JObject and
-      node.hasKey("protocol") and node["protocol"].kind == JInt and
-      node["protocol"].getBiggestInt == CONTROL_PROTOCOL and
-      node.hasKey("token") and node["token"].kind == JString and
-      constantTimeEqual(node["token"].getStr, token) and
-      node.hasKey("operation") and node["operation"].kind == JString and
-      node["operation"].getStr == "ex" and
-      node.hasKey("command") and node["command"].kind == JString
-
-proc handleClient(socket: Socket, instance, token: string, index: int) =
-    let challengeFrame = recvSocketFrame(socket, AUTH_TIMEOUT_MS,
-      stopAware = true)
-    if challengeFrame.kind == sfkEof:
-        return
-    if challengeFrame.kind == sfkInvalid:
-        sendSocketFrame(socket, errorResponse(challengeFrame.error))
-        return
-
-    var challenge: JsonNode
-    try:
-        challenge = parseJson(challengeFrame.payload)
-    except JsonParsingError:
-        sendSocketFrame(socket, errorResponse("invalid challenge"))
-        return
-    if challenge.kind != JObject or
-      not challenge.hasKey("protocol") or challenge["protocol"].kind != JInt or
-      challenge["protocol"].getBiggestInt != CONTROL_PROTOCOL or
-      not challenge.hasKey("challenge") or challenge["challenge"].kind != JString or
-      not isHex(challenge["challenge"].getStr, 32):
-        sendSocketFrame(socket, errorResponse("invalid challenge"))
-        return
-    sendSocketFrame(socket, $(%*{
-        "protocol": CONTROL_PROTOCOL,
-        "instance": instance,
-        "proof": controlProof(token, challenge["challenge"].getStr)
-    }))
-
-    let incoming = recvSocketFrame(socket, AUTH_TIMEOUT_MS, stopAware = true)
-    if incoming.kind == sfkEof:
-        return
-    if incoming.kind == sfkInvalid:
-        sendSocketFrame(socket, errorResponse(incoming.error))
-        return
-
+proc handleClient(socket: Socket, token: string, index: int) =
     var request: JsonNode
     try:
-        request = parseJson(incoming.payload)
-    except JsonParsingError:
-        sendSocketFrame(socket, errorResponse("invalid request"))
+        request = receiveJson(socket, CLIENT_TIMEOUT_MS)
+    except CatchableError:
+        sendLine(socket, errorResponse("invalid control request"))
         return
-    if not validCliRequest(request, token):
-        sendSocketFrame(socket, errorResponse("authentication failed"))
+    if not validRequest(request, token):
+        sendLine(socket, errorResponse("authentication failed"))
         return
 
     let id = randomHex(16)
-    let nativeRequest = %*{
+    setPending(index, id)
+    defer: clearPending(index)
+    if not writeNative($(%*{
         "type": "control.request",
         "protocol": CONTROL_PROTOCOL,
         "id": id,
         "operation": "ex",
         "command": request["command"].getStr
-    }
-    setPending(index, id)
-    defer: clearPending(index, id)
-    if not writeNative($nativeRequest):
-        sendSocketFrame(socket, errorResponse("extension disconnected"))
+    })):
+        sendLine(socket, errorResponse("extension disconnected"))
         return
-    sendSocketFrame(socket, waitForExtension(index))
+    sendLine(socket, waitForExtension(index))
 
 proc clientMain(arguments: WorkerArgs) {.thread.} =
     try:
-        handleClient(arguments.socket, arguments.instance, arguments.token,
-          arguments.index)
+        handleClient(arguments.socket, arguments.token, arguments.index)
     except CatchableError:
         try:
-            sendSocketFrame(arguments.socket, errorResponse("control request failed"))
+            sendLine(arguments.socket,
+              errorResponse("control request failed"))
         except CatchableError:
             discard
     finally:
         arguments.socket.close()
-        acquire(stateLock)
-        workerDone[arguments.index] = true
-        release(stateLock)
+        completedWorkers.send(arguments.index)
 
-proc listenerMain() {.thread.} =
+proc listenerMain(arguments: ListenerArgs) {.thread.} =
     var
-        server: Socket
-        recordPath = ""
-        announced = false
         workers: array[MAX_CLIENTS, Thread[WorkerArgs]]
         workerUsed: array[MAX_CLIENTS, bool]
     try:
-        let token = randomHex(32)
-        let instance = randomHex(16)
-        server = newSocket(buffered = false)
-        server.bindAddr(Port(0), "127.0.0.1")
-        server.listen()
-        let (_, boundPort) = server.getLocalAddr()
-        let port = boundPort.int
-        recordPath = publishRecord(instance, token, port)
-        startupChannel.send(StartupResult(ok: true, port: port,
-          instance: instance))
-        announced = true
-
-        while not shouldStop().stop:
+        while not stopping().stop:
             var client: Socket
-            server.accept(client)
-            if shouldStop().stop:
+            arguments.server.accept(client)
+            if stopping().stop:
                 client.close()
                 break
 
-            for index in 0 ..< MAX_CLIENTS:
-                if workerUsed[index]:
-                    acquire(stateLock)
-                    let done = workerDone[index]
-                    release(stateLock)
-                    if done:
-                        joinThread(workers[index])
-                        workerUsed[index] = false
-
-            var workerIndex = -1
-            for index in 0 ..< MAX_CLIENTS:
-                if not workerUsed[index]:
-                    workerIndex = index
+            while true:
+                let completed = completedWorkers.tryRecv()
+                if not completed.dataAvailable:
                     break
-            if workerIndex < 0:
+                if workerUsed[completed.msg]:
+                    joinThread(workers[completed.msg])
+                    workerUsed[completed.msg] = false
+
+            let index = workerUsed.find(false)
+            if index < 0:
                 client.close()
                 continue
-
-            acquire(stateLock)
-            workerDone[workerIndex] = false
-            release(stateLock)
             try:
-                createThread(workers[workerIndex], clientMain,
-                  WorkerArgs(socket: client, instance: instance, token: token,
-                    index: workerIndex))
-                workerUsed[workerIndex] = true
+                createThread(workers[index], clientMain,
+                  WorkerArgs(socket: client, token: arguments.token,
+                    index: index))
+                workerUsed[index] = true
             except CatchableError:
                 client.close()
     except CatchableError:
-        if not announced:
-            startupChannel.send(StartupResult(ok: false,
-              error: "could not start the control endpoint"))
-        else:
-            stderr.writeLine("Control endpoint stopped unexpectedly")
+        stderr.writeLine("Control endpoint stopped unexpectedly")
     finally:
-        acquire(stateLock)
-        stopRequested = true
-        release(stateLock)
-        if server != nil:
-            server.close()
-        removeRecord(recordPath)
+        withLock stateLock:
+            stopRequested = true
+        arguments.server.close()
+        removeRecord(arguments.recordPath)
         for index in 0 ..< MAX_CLIENTS:
             if workerUsed[index]:
                 joinThread(workers[index])
-        acquire(stateLock)
-        listenerExited = true
-        release(stateLock)
+        withLock stateLock:
+            listenerExited = true
 
 proc listenerHasExited(): bool =
-    acquire(stateLock)
-    result = listenerExited
-    release(stateLock)
+    withLock stateLock:
+        result = listenerExited
 
 proc startControl*(): ControlStart =
     if listenerStarted and not listenerHasExited():
@@ -551,26 +334,32 @@ proc startControl*(): ControlStart =
         joinThread(listenerThread)
         listenerStarted = false
 
-    acquire(stateLock)
-    stopRequested = false
-    stopIsDisconnect = false
-    listenerExited = false
-    release(stateLock)
+    withLock stateLock:
+        stopRequested = false
+        stopIsDisconnect = false
+        listenerExited = false
+    var server: Socket
+    var recordPath = ""
     try:
-        createThread(listenerThread, listenerMain)
+        let
+            token = randomHex(32)
+            instance = randomHex(16)
+        server = newSocket(buffered = false)
+        server.bindAddr(Port(0), "127.0.0.1")
+        server.listen()
+        let (_, port) = server.getLocalAddr()
+        recordPath = publishRecord(instance, token, port.int)
+        createThread(listenerThread, listenerMain, ListenerArgs(server: server,
+          recordPath: recordPath, token: token))
         listenerStarted = true
+        listenerPort = port.int
+        activeInstance = instance
+        result = ControlStart(ok: true, instance: instance)
     except CatchableError:
-        return ControlStart(error: "could not create the control thread")
-
-    let startup = startupChannel.recv()
-    if not startup.ok:
-        joinThread(listenerThread)
-        listenerStarted = false
-        return ControlStart(error: startup.error)
-
-    listenerPort = startup.port
-    activeInstance = startup.instance
-    ControlStart(ok: true, instance: startup.instance)
+        if server != nil:
+            server.close()
+        removeRecord(recordPath)
+        result.error = "could not start the control endpoint"
 
 proc wakeListener(port: int) =
     if port == 0:
@@ -588,10 +377,9 @@ proc wakeListener(port: int) =
 proc stopControl*(extensionDisconnected = false) =
     if not listenerStarted:
         return
-    acquire(stateLock)
-    stopRequested = true
-    stopIsDisconnect = extensionDisconnected
-    release(stateLock)
+    withLock stateLock:
+        stopRequested = true
+        stopIsDisconnect = extensionDisconnected
     wakeListener(listenerPort)
     joinThread(listenerThread)
     listenerStarted = false
@@ -601,19 +389,14 @@ proc stopControl*(extensionDisconnected = false) =
 proc deliverControlResponse*(id, payload: string): bool =
     if id.len != pendingSlots[0].id.len:
         return false
-    acquire(stateLock)
-    var selected = -1
-    for index in 0 ..< MAX_CLIENTS:
-        var matches = pendingSlots[index].active
-        for idIndex in 0 ..< pendingSlots[index].id.len:
-            matches = matches and pendingSlots[index].id[idIndex] == id[idIndex]
-        if matches:
-            selected = index
-            break
-    if selected >= 0:
-        pendingSlots[selected].replies.send(payload)
-        result = true
-    release(stateLock)
+    withLock stateLock:
+        for slot in pendingSlots.mitems:
+            var matches = slot.active
+            for index, character in id:
+                matches = matches and slot.id[index] == character
+            if matches:
+                slot.replies.send(payload)
+                return true
 
 proc loadRecords(): seq[DiscoveryRecord] =
     let directory = discoveryDirectory()
@@ -621,88 +404,29 @@ proc loadRecords(): seq[DiscoveryRecord] =
         return
     for path in walkFiles(directory / "*.json"):
         try:
-            let node = parseFile(path)
-            if node.kind != JObject or
-              not node.hasKey("protocol") or node["protocol"].kind != JInt or
-              node["protocol"].getBiggestInt != CONTROL_PROTOCOL or
-              not node.hasKey("instance") or node["instance"].kind != JString or
-              not node.hasKey("token") or node["token"].kind != JString or
-              not node.hasKey("port") or node["port"].kind != JInt or
-              not node.hasKey("pid") or node["pid"].kind != JInt:
-                raise newException(ValueError, "invalid discovery record")
-            let port = node["port"].getBiggestInt
-            let pid = node["pid"].getBiggestInt
-            if port < 1 or port > 65_535 or pid < 1 or
-              pid > BiggestInt(high(int32)):
+            let data = parseFile(path).to(DiscoveryData)
+            let maxPid =
+                when defined(windows): BiggestInt(high(uint32))
+                else: BiggestInt(high(int32))
+            if data.protocol != CONTROL_PROTOCOL or data.port < 1 or
+              data.port > 65_535 or data.pid < 1 or data.pid > maxPid:
                 raise newException(ValueError, "invalid discovery record")
             let record = DiscoveryRecord(
                 path: path,
-                instance: node["instance"].getStr,
-                token: node["token"].getStr,
-                port: port.int,
-                pid: pid.int,
+                instance: data.instance,
+                token: data.token,
+                port: data.port.int,
+                pid: data.pid,
             )
             if not isHex(record.instance, 32) or not isHex(record.token, 64) or
               path.extractFilename != record.instance & ".json":
                 raise newException(ValueError, "invalid discovery record")
-            result.add(record)
+            if processMayExist(record.pid):
+                result.add(record)
+            else:
+                removeRecord(path)
         except CatchableError:
             removeRecord(path)
-
-proc authenticateServer(socket: Socket, record: DiscoveryRecord,
-        timeout = AUTH_TIMEOUT_MS): ServerAuth =
-    let challenge = randomHex(16)
-    try:
-        sendSocketFrame(socket, $(%*{
-            "protocol": CONTROL_PROTOCOL,
-            "challenge": challenge
-        }))
-    except CatchableError:
-        return saUnavailable
-    let responseFrame = recvSocketFrame(socket, timeout)
-    if responseFrame.kind == sfkEof:
-        return saUnavailable
-    if responseFrame.kind != sfkMessage:
-        return saUnavailable
-    var response: JsonNode
-    try:
-        response = parseJson(responseFrame.payload)
-    except JsonParsingError:
-        return saInvalid
-    if response.kind == JObject and
-      response.hasKey("protocol") and response["protocol"].kind == JInt and
-      response["protocol"].getBiggestInt == CONTROL_PROTOCOL and
-      response.hasKey("instance") and response["instance"].kind == JString and
-      response["instance"].getStr == record.instance and
-      response.hasKey("proof") and response["proof"].kind == JString and
-      constantTimeEqual(response["proof"].getStr,
-        controlProof(record.token, challenge)):
-        saAuthenticated
-    else:
-        saInvalid
-
-proc canConnect(record: DiscoveryRecord): bool =
-    var socket: Socket
-    try:
-        socket = newSocket(buffered = false)
-        socket.connect("127.0.0.1", Port(record.port), timeout = PROBE_TIMEOUT_MS)
-        let authenticated = authenticateServer(socket, record,
-          PROBE_TIMEOUT_MS)
-        result = authenticated == saAuthenticated
-        if authenticated == saInvalid:
-            removeRecord(record.path)
-        elif authenticated == saUnavailable:
-            removeRecordIfDead(record)
-    except CatchableError:
-        removeRecordIfDead(record)
-    finally:
-        if socket != nil:
-            socket.close()
-
-proc liveRecords(records: seq[DiscoveryRecord]): seq[DiscoveryRecord] =
-    for record in records:
-        if canConnect(record):
-            result.add(record)
     result.sort(proc(left, right: DiscoveryRecord): int =
       cmp(left.instance, right.instance))
 
@@ -711,21 +435,17 @@ proc chooseRecord(selector: string): tuple[ok: bool, record: DiscoveryRecord,
     var records = loadRecords()
     if selector.len > 0:
         records = records.filterIt(it.instance.startsWith(selector))
-    records = liveRecords(records)
-    if selector.len > 0:
         if records.len == 0:
-            return (false, DiscoveryRecord(), "no native host matches instance " & selector)
+            return (false, DiscoveryRecord(),
+              "no native host matches instance " & selector)
         if records.len > 1:
             return (false, DiscoveryRecord(), "instance selector is ambiguous")
     elif records.len == 0:
         return (false, DiscoveryRecord(), "no opted-in native host found")
     elif records.len > 1:
-        var instances: seq[string]
-        for record in records:
-            instances.add(record.instance)
         return (false, DiscoveryRecord(),
           "multiple opted-in native hosts found; use --instance with one of: " &
-          instances.join(", "))
+          records.mapIt(it.instance).join(", "))
     (true, records[0], "")
 
 proc runCli*(command, selector: string): int =
@@ -739,42 +459,28 @@ proc runCli*(command, selector: string): int =
         socket = newSocket(buffered = false)
         socket.connect("127.0.0.1", Port(selected.record.port),
           timeout = PROBE_TIMEOUT_MS)
-        if authenticateServer(socket, selected.record) != saAuthenticated:
-            stderr.writeLine("selected native host failed authentication")
-            return 1
-        let request = %*{
+        sendLine(socket, $(%*{
             "protocol": CONTROL_PROTOCOL,
             "token": selected.record.token,
             "operation": "ex",
             "command": command
-        }
-        sendSocketFrame(socket, $request)
-        let responseFrame = recvSocketFrame(socket, CLI_RESPONSE_TIMEOUT_MS)
-        if responseFrame.kind != sfkMessage:
-            stderr.writeLine(if responseFrame.error.len > 0:
-              responseFrame.error else: "control connection closed")
-            return 1
-
-        let response = parseJson(responseFrame.payload)
-        if response.kind != JObject or
-          not response.hasKey("protocol") or response["protocol"].kind != JInt or
-          response["protocol"].getBiggestInt != CONTROL_PROTOCOL or
-          not response.hasKey("ok") or response["ok"].kind != JBool:
+        }))
+        let response = receiveJson(socket, CLI_RESPONSE_TIMEOUT_MS)
+        let ok = response{"ok"}
+        if not validProtocol(response) or ok.isNil or ok.kind != JBool:
             stderr.writeLine("invalid control response")
             return 1
         if not response["ok"].getBool:
-            if response.hasKey("error") and response["error"].kind == JString:
-                stderr.writeLine(response["error"].getStr)
-            else:
-                stderr.writeLine("control request failed")
+            stderr.writeLine(if response.hasKey("error") and
+              response["error"].kind == JString: response["error"].getStr
+              else: "control request failed")
             return 1
         if response.hasKey("result"):
-            if response["result"].kind == JString:
-                stdout.writeLine(response["result"].getStr)
-            else:
-                stdout.writeLine($response["result"])
+            stdout.writeLine(if response["result"].kind == JString:
+              response["result"].getStr else: $response["result"])
         result = 0
     except CatchableError:
+        removeRecordIfDead(selected.record)
         stderr.writeLine("could not contact the selected native host")
         result = 1
     finally:

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -7,6 +7,7 @@ import strutils
 import posix
 import regex
 import base64
+import control_bridge
 
 # Third party stuff
 import tempfile
@@ -15,7 +16,7 @@ import tempfile
 when defined(windows):
     import windows_helpers
 
-const VERSION = "0.5.0"
+const VERSION = "0.6.0"
 
 type
     MessageRecv* = object
@@ -29,7 +30,7 @@ type
         cmd*, version*, error*, sep*: string
         content*, command*: Option[string]
 
-        files: seq[string]
+        files, capabilities: seq[string]
 
         isDir: bool
         code: Option[int]
@@ -52,6 +53,9 @@ func toJson(m: MessageResp): JsonNode =
                 for file in value:
                     files.add file.newJString
                 result[name] = files
+        elif name == "capabilities":
+            if value.len > 0:
+                result[name] = %value
         else:
             {.error: "Unhandled MessageResp field: " & name.}
 
@@ -63,25 +67,6 @@ func sanitiseFilename(fn: string): string =
             result.add c
 
     result = result.replace("..", ".")
-
-proc getMessage(strm: Stream): MessageRecv =
-    try:
-        var length: int32
-        read(strm, length)
-        if length == 0:
-            close(strm)
-            quit(0)
-
-        let
-            message = readStr(strm, length)
-            rawJson = parseJson(message)
-
-        return rawJson.to(MessageRecv)
-
-    except IOError:
-        close(strm)
-        quit(0)
-
 
 proc findUserConfigFile(): string =
     # The standard config dir is the same as stdlib, except on Windows where we also allow `XDG_CONFIG_HOME` when set.
@@ -140,6 +125,7 @@ proc handleMessage(msg: MessageRecv): MessageResp =
     case cmd:
         of "version":
             result.version = VERSION
+            result.capabilities = @[CONTROL_CAPABILITY]
             result.code = some 0
 
         of "getconfig":
@@ -369,8 +355,86 @@ proc handleMessage(msg: MessageRecv): MessageResp =
             result.error = "Unhandled message"
             write(stderr, "Unhandled message: " & $msg & "\n")
 
+func errorMessage(message: string): JsonNode =
+    var response: MessageResp
+    response.cmd = "error"
+    response.error = message
+    response.toJson
+
+proc handshakeResponse(message: JsonNode): JsonNode =
+    result = %*{
+        "type": "control.handshake",
+        "protocol": CONTROL_PROTOCOL,
+        "enabled": false
+    }
+    if not message.hasKey("protocol") or message["protocol"].kind != JInt or
+      message["protocol"].getBiggestInt != CONTROL_PROTOCOL:
+        result["error"] = %"unsupported control protocol"
+        return
+    if not message.hasKey("enable") or message["enable"].kind != JBool:
+        result["error"] = %"handshake requires a boolean enable field"
+        return
+
+    if not message["enable"].getBool:
+        stopControl()
+        return
+
+    let started = startControl()
+    if started.ok:
+        result["enabled"] = %true
+        result["instance"] = %started.instance
+    else:
+        result["error"] = %started.error
+
+proc relayControlResponse(message: JsonNode) =
+    if not message.hasKey("id") or message["id"].kind != JString:
+        stderr.writeLine("Ignoring a control response without an ID")
+        return
+    let id = message["id"].getStr
+    var response = %*{"protocol": CONTROL_PROTOCOL, "ok": false}
+    if not message.hasKey("protocol") or message["protocol"].kind != JInt or
+      message["protocol"].getBiggestInt != CONTROL_PROTOCOL or
+      not message.hasKey("ok") or message["ok"].kind != JBool:
+        response["error"] = %"invalid extension response"
+    elif message["ok"].getBool:
+        response["ok"] = %true
+        if message.hasKey("result"):
+            response["result"] = message["result"]
+    elif message.hasKey("error") and message["error"].kind == JString:
+        response["error"] = message["error"]
+    else:
+        response["error"] = %"extension request failed"
+    discard deliverControlResponse(id, $response)
+
+proc runRequestMode(params: seq[string]): int =
+    var
+        command = ""
+        instance = ""
+        index = 1
+    while index < params.len:
+        if params[index] == "--instance":
+            if index + 1 >= params.len or instance.len > 0:
+                stderr.writeLine("Usage: native_main --request COMMAND [--instance ID]")
+                return 2
+            instance = params[index + 1]
+            index += 2
+        elif command.len == 0:
+            command = params[index]
+            inc index
+        else:
+            stderr.writeLine("Usage: native_main --request COMMAND [--instance ID]")
+            return 2
+    if command.len == 0:
+        stderr.writeLine("Usage: native_main --request COMMAND [--instance ID]")
+        return 2
+    runCli(command, instance)
+
+proc printUsage() =
+    stdout.writeLine("Usage: native_main --request COMMAND [--instance ID]")
+    stdout.writeLine("       native_main --version")
+
+let params = commandLineParams()
 when defined windows:
-    let params = commandLineParams()
     # Usage: native_main.exe restart <Firefox PID> <profile dir> <browser exe name>
     # This should only invoked by the native messenger itself to perform
     # :restart on Windows. See also windows_restart.getOrphanMessengerCommand.
@@ -379,12 +443,56 @@ when defined windows:
           profiledir = params[2], browserExePath = params[3])
         quit()
 
+if params.len > 0 and params[0] == "--request":
+    quit(runRequestMode(params))
+if params == @["--help"]:
+    printUsage()
+    quit(0)
+if params == @["--version"]:
+    stdout.writeLine(VERSION)
+    quit(0)
+
+initControlBridge()
 let strm = newFileStream(stdin)
 
 while true:
-    let
-        message = $handleMessage(getMessage(strm)).toJson
-        lengthPayload = cast[array[4, byte]](message.len.uint32)
-    discard writeBytes(stdout, lengthPayload, 0, lengthPayload.len)
-    write(stdout, message)
-    flushFile(stdout)
+    let frame = readNativeFrame(strm)
+    if frame.kind == nfkEof:
+        break
+    if frame.kind == nfkInvalid:
+        stderr.writeLine(frame.error)
+        break
+
+    var message: JsonNode
+    try:
+        message = parseJson(frame.payload)
+    except JsonParsingError:
+        stderr.writeLine("Malformed native JSON message")
+        if not writeNative($errorMessage("Malformed native message")):
+            break
+        continue
+
+    if message.kind != JObject:
+        if not writeNative($errorMessage("Malformed native message")):
+            break
+    elif message.hasKey("cmd"):
+        try:
+            if not writeNative($handleMessage(message.to(MessageRecv)).toJson):
+                break
+        except Exception:
+            stderr.writeLine("Malformed legacy native message")
+            if not writeNative($errorMessage("Malformed native message")):
+                break
+    elif message.hasKey("type") and message["type"].kind == JString and
+      message["type"].getStr == "control.handshake":
+        if not writeNative($handshakeResponse(message)):
+            break
+    elif message.hasKey("type") and message["type"].kind == JString and
+      message["type"].getStr == "control.response":
+        relayControlResponse(message)
+    else:
+        if not writeNative($errorMessage("Unhandled message")):
+            break
+
+stopControl(extensionDisconnected = true)
+strm.close()

--- a/src/native_main.nim
+++ b/src/native_main.nim
@@ -16,7 +16,9 @@ import tempfile
 when defined(windows):
     import windows_helpers
 
-const VERSION = "0.6.0"
+const
+    VERSION = "0.6.0"
+    MAX_NATIVE_FRAME = 64 * 1024 * 1024
 
 type
     MessageRecv* = object
@@ -67,6 +69,22 @@ func sanitiseFilename(fn: string): string =
             result.add c
 
     result = result.replace("..", ".")
+
+proc getMessage(stream: Stream): JsonNode =
+    try:
+        var size: uint32
+        stream.read(size)
+        if size == 0:
+            return
+        if size > MAX_NATIVE_FRAME.uint32:
+            raise newException(ValueError,
+              "native message exceeds maximum frame length")
+        let payload = stream.readStr(size.int)
+        if payload.len != size.int:
+            raise newException(IOError, "truncated native message payload")
+        result = parseJson(payload)
+    except IOError:
+        discard
 
 proc findUserConfigFile(): string =
     # The standard config dir is the same as stdlib, except on Windows where we also allow `XDG_CONFIG_HOME` when set.
@@ -356,10 +374,7 @@ proc handleMessage(msg: MessageRecv): MessageResp =
             write(stderr, "Unhandled message: " & $msg & "\n")
 
 func errorMessage(message: string): JsonNode =
-    var response: MessageResp
-    response.cmd = "error"
-    response.error = message
-    response.toJson
+    %*{"cmd": "error", "error": message}
 
 proc handshakeResponse(message: JsonNode): JsonNode =
     result = %*{
@@ -387,47 +402,18 @@ proc handshakeResponse(message: JsonNode): JsonNode =
         result["error"] = %started.error
 
 proc relayControlResponse(message: JsonNode) =
-    if not message.hasKey("id") or message["id"].kind != JString:
+    let id = message{"id"}.getStr
+    if id.len == 0:
         stderr.writeLine("Ignoring a control response without an ID")
         return
-    let id = message["id"].getStr
-    var response = %*{"protocol": CONTROL_PROTOCOL, "ok": false}
-    if not message.hasKey("protocol") or message["protocol"].kind != JInt or
-      message["protocol"].getBiggestInt != CONTROL_PROTOCOL or
-      not message.hasKey("ok") or message["ok"].kind != JBool:
-        response["error"] = %"invalid extension response"
-    elif message["ok"].getBool:
-        response["ok"] = %true
-        if message.hasKey("result"):
-            response["result"] = message["result"]
-    elif message.hasKey("error") and message["error"].kind == JString:
-        response["error"] = message["error"]
-    else:
-        response["error"] = %"extension request failed"
-    discard deliverControlResponse(id, $response)
+    discard deliverControlResponse(id, $message)
 
 proc runRequestMode(params: seq[string]): int =
-    var
-        command = ""
-        instance = ""
-        index = 1
-    while index < params.len:
-        if params[index] == "--instance":
-            if index + 1 >= params.len or instance.len > 0:
-                stderr.writeLine("Usage: native_main --request COMMAND [--instance ID]")
-                return 2
-            instance = params[index + 1]
-            index += 2
-        elif command.len == 0:
-            command = params[index]
-            inc index
-        else:
-            stderr.writeLine("Usage: native_main --request COMMAND [--instance ID]")
-            return 2
-    if command.len == 0:
+    if params.len notin [2, 4] or params[1].len == 0 or
+      (params.len == 4 and (params[2] != "--instance" or params[3].len == 0)):
         stderr.writeLine("Usage: native_main --request COMMAND [--instance ID]")
         return 2
-    runCli(command, instance)
+    runCli(params[1], if params.len == 4: params[3] else: "")
 
 proc printUsage() =
     stdout.writeLine("Usage: native_main --request COMMAND [--instance ID]")
@@ -456,43 +442,38 @@ initControlBridge()
 let strm = newFileStream(stdin)
 
 while true:
-    let frame = readNativeFrame(strm)
-    if frame.kind == nfkEof:
-        break
-    if frame.kind == nfkInvalid:
-        stderr.writeLine(frame.error)
-        break
-
     var message: JsonNode
     try:
-        message = parseJson(frame.payload)
+        message = getMessage(strm)
     except JsonParsingError:
         stderr.writeLine("Malformed native JSON message")
         if not writeNative($errorMessage("Malformed native message")):
             break
         continue
+    except ValueError as error:
+        stderr.writeLine(error.msg)
+        break
+    if message.isNil:
+        break
 
+    var response: JsonNode
     if message.kind != JObject:
-        if not writeNative($errorMessage("Malformed native message")):
-            break
+        response = errorMessage("Malformed native message")
     elif message.hasKey("cmd"):
         try:
-            if not writeNative($handleMessage(message.to(MessageRecv)).toJson):
-                break
+            response = handleMessage(message.to(MessageRecv)).toJson
         except Exception:
             stderr.writeLine("Malformed legacy native message")
-            if not writeNative($errorMessage("Malformed native message")):
-                break
-    elif message.hasKey("type") and message["type"].kind == JString and
-      message["type"].getStr == "control.handshake":
-        if not writeNative($handshakeResponse(message)):
-            break
-    elif message.hasKey("type") and message["type"].kind == JString and
-      message["type"].getStr == "control.response":
+            response = errorMessage("Malformed native message")
+    elif message{"type"}.getStr == "control.handshake":
+        response = handshakeResponse(message)
+    elif message{"type"}.getStr == "control.response":
         relayControlResponse(message)
+        continue
     else:
-        if not writeNative($errorMessage("Unhandled message")):
-            break
+        response = errorMessage("Unhandled message")
+    if not writeNative($response):
+        break
 
 stopControl(extensionDisconnected = true)
 strm.close()

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-import hashlib
 import json
 import os
 import queue
 import socket
 import struct
 import subprocess
-import threading
 import tempfile
+import threading
 import time
 import unittest
 from pathlib import Path
@@ -15,14 +14,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 BINARY = ROOT / ("native_main.exe" if os.name == "nt" else "native_main")
-MAX_CLI_FRAME = 1024 * 1024
 MAX_NATIVE_FRAME = 64 * 1024 * 1024
-
-
-def frame(payload):
-    if not isinstance(payload, bytes):
-        payload = json.dumps(payload, separators=(",", ":")).encode()
-    return struct.pack("<I", len(payload)) + payload
 
 
 def native_frame(payload):
@@ -41,37 +33,26 @@ def read_exact(stream, size):
     return bytes(data)
 
 
-def read_message(stream):
+def read_native(stream):
     size = struct.unpack("=I", read_exact(stream, 4))[0]
     return json.loads(read_exact(stream, size))
 
 
-def recv_exact(sock, size):
+def send_line(sock, payload):
+    sock.sendall(json.dumps(payload, separators=(",", ":")).encode() + b"\n")
+
+
+def recv_line(sock):
     data = bytearray()
-    while len(data) < size:
-        chunk = sock.recv(size - len(data))
+    while b"\n" not in data:
+        chunk = sock.recv(4096)
         if not chunk:
-            raise EOFError(f"wanted {size} bytes, got {len(data)}")
+            raise EOFError("connection closed")
         data.extend(chunk)
-    return bytes(data)
-
-
-def recv_message(sock):
-    size = struct.unpack("<I", recv_exact(sock, 4))[0]
-    return json.loads(recv_exact(sock, size))
-
-
-def authenticate(sock, record):
-    challenge = os.urandom(16).hex()
-    sock.sendall(frame({"protocol": 1, "challenge": challenge}))
-    response = recv_message(sock)
-    expected = hashlib.sha1((record["token"] + challenge).encode()).hexdigest()
-    if (
-        response.get("protocol") != 1
-        or response.get("instance") != record["instance"]
-        or response.get("proof", "").lower() != expected
-    ):
-        raise AssertionError("control host failed authentication")
+    line, _, remainder = data.partition(b"\n")
+    if remainder:
+        raise AssertionError("unexpected data after control response")
+    return json.loads(line)
 
 
 class Host:
@@ -96,7 +77,7 @@ class Host:
     def _read_messages(self):
         try:
             while True:
-                self.messages.put(read_message(self.stdout))
+                self.messages.put(read_native(self.stdout))
         except EOFError:
             pass
         except Exception as error:
@@ -137,14 +118,12 @@ class Host:
 class NativeControlTest(unittest.TestCase):
     def setUp(self):
         if not BINARY.exists():
-            self.fail("native_main is missing; run `nimble build` before this test")
+            self.fail("native_main is missing; run `nimble build` before testing")
         self.cache = tempfile.TemporaryDirectory()
         self.addCleanup(self.cache.cleanup)
         self.env = os.environ.copy()
-        self.env["XDG_CACHE_HOME"] = self.cache.name
-        self.env["LOCALAPPDATA"] = self.cache.name
-        self.env["HOME"] = self.cache.name
-        self.env["USERPROFILE"] = self.cache.name
+        for name in ("XDG_CACHE_HOME", "LOCALAPPDATA", "HOME", "USERPROFILE"):
+            self.env[name] = self.cache.name
 
     def records(self):
         return list(Path(self.cache.name).glob("**/native-control/*.json"))
@@ -162,114 +141,78 @@ class NativeControlTest(unittest.TestCase):
         )
 
     def run_cli(self, command, instance=None):
-        return self.start_cli(command, instance).communicate(timeout=5)
+        process = self.start_cli(command, instance)
+        stdout, stderr = process.communicate(timeout=5)
+        return process, stdout, stderr
 
     def assert_no_native_output(self, host):
         with self.assertRaises(queue.Empty):
-            host.messages.get(timeout=0.2)
+            host.messages.get(timeout=0.1)
 
-    def test_legacy_control_cli_and_shutdown(self):
+    def enable(self, host):
+        response = host.request(
+            {"type": "control.handshake", "protocol": 1, "enable": True}
+        )
+        self.assertTrue(response["enabled"])
+        return response["instance"]
+
+    def respond(self, host, request, ok=True, **extra):
+        host.send(
+            {
+                "type": "control.response",
+                "protocol": 1,
+                "id": request["id"],
+                "ok": ok,
+                **extra,
+            }
+        )
+
+    def test_control_cli_and_shutdown(self):
         host = Host(self.env)
         self.addCleanup(host.cleanup)
 
         version = host.request({"cmd": "version"})
-        self.assertEqual(version["cmd"], "version")
         self.assertEqual(version["version"], "0.6.0")
-        self.assertEqual(version["code"], 0)
         self.assertIn("control-port-v1", version["capabilities"])
         self.assertEqual(self.records(), [])
-
-        stdout, stderr = self.run_cli("tabopen example.com")
-        self.assertEqual(stdout, "")
-        self.assertIn("no opted-in native host", stderr.lower())
+        process, _, stderr = self.run_cli("tabopen x")
+        self.assertNotEqual(process.returncode, 0)
+        self.assertIn("no opted-in native host", stderr)
 
         host.send(b"{not-json")
-        malformed = host.receive()
-        self.assertEqual(malformed["cmd"], "error")
-        self.assertIn("malformed", malformed["error"].lower())
-        malformed = host.request({"cmd": "run"})
-        self.assertEqual(malformed["cmd"], "error")
-        self.assertEqual(host.request({"cmd": "version"})["version"], "0.6.0")
-        invalid_protocol = host.request(
-            {"type": "control.handshake", "protocol": 2**40, "enable": True}
-        )
-        self.assertFalse(invalid_protocol["enabled"])
+        self.assertEqual(host.receive()["cmd"], "error")
         self.assertEqual(host.request({"cmd": "version"})["version"], "0.6.0")
 
-        disabled = host.request(
-            {"type": "control.handshake", "protocol": 1, "enable": False}
-        )
-        self.assertEqual(
-            disabled,
-            {"type": "control.handshake", "protocol": 1, "enabled": False},
-        )
-        self.assertEqual(self.records(), [])
-
-        enabled = host.request(
-            {"type": "control.handshake", "protocol": 1, "enable": True}
-        )
-        self.assertTrue(enabled["enabled"])
-        instance = enabled["instance"]
+        instance = self.enable(host)
         record_path = self.records()[0]
-        discovery_dir = record_path.parent
         record = json.loads(record_path.read_text())
         self.assertEqual(record["instance"], instance)
-        self.assertEqual(record["protocol"], 1)
         if os.name == "posix":
             self.assertEqual(record_path.stat().st_mode & 0o077, 0)
-            self.assertEqual(discovery_dir.stat().st_mode & 0o077, 0)
+            self.assertEqual(record_path.parent.stat().st_mode & 0o077, 0)
 
-        saturated = [
-            socket.create_connection(("127.0.0.1", record["port"]), timeout=1)
-            for _ in range(40)
-        ]
-        try:
-            stdout, stderr = self.run_cli("tabopen saturated.example")
-            self.assertEqual(stdout, "")
-            self.assertIn("no opted-in native host", stderr.lower())
-            self.assertTrue(record_path.exists())
-        finally:
-            for client in saturated:
-                client.close()
-
-        with socket.create_connection(("127.0.0.1", record["port"]), timeout=1) as sock:
-            authenticate(sock, record)
-            sock.sendall(
-                frame(
-                    {
-                        "protocol": 1,
-                        "token": "wrong",
-                        "operation": "ex",
-                        "command": "quitall",
-                    }
-                )
-            )
-            self.assertFalse(recv_message(sock)["ok"])
-        self.assert_no_native_output(host)
-
-        with socket.create_connection(("127.0.0.1", record["port"]), timeout=1) as sock:
-            authenticate(sock, record)
-            sock.sendall(struct.pack("<I", MAX_CLI_FRAME + 1))
-            self.assertFalse(recv_message(sock)["ok"])
-        self.assert_no_native_output(host)
-
-        reset = socket.create_connection(("127.0.0.1", record["port"]), timeout=1)
-        authenticate(reset, record)
-        reset.sendall(
-            frame(
+        with socket.create_connection(("127.0.0.1", record["port"])) as client:
+            send_line(
+                client,
                 {
                     "protocol": 1,
                     "token": "wrong",
                     "operation": "ex",
                     "command": "quitall",
-                }
+                },
             )
-        )
-        reset.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
-        reset.close()
-        self.assertEqual(host.request({"cmd": "version"})["version"], "0.6.0")
+            self.assertEqual(recv_line(client)["error"], "authentication failed")
+        self.assert_no_native_output(host)
 
-        stale_path = discovery_dir / ("0" * 32 + ".json")
+        disabled = host.request(
+            {"type": "control.handshake", "protocol": 1, "enable": False}
+        )
+        self.assertFalse(disabled["enabled"])
+        self.assertEqual(self.records(), [])
+        instance = self.enable(host)
+        record_path = self.records()[0]
+
+        stale_path = record_path.parent / ("0" * 32 + ".json")
         stale_path.write_text(
             json.dumps(
                 {
@@ -282,162 +225,102 @@ class NativeControlTest(unittest.TestCase):
             )
         )
         os.chmod(stale_path, 0o600)
-        invalid_pid_path = discovery_dir / ("1" * 32 + ".json")
-        invalid_pid_path.write_text(
-            json.dumps(
-                {
-                    "protocol": 1,
-                    "instance": "1" * 32,
-                    "port": 1,
-                    "token": "1" * 64,
-                    "pid": 2**31,
-                }
-            )
-        )
-        os.chmod(invalid_pid_path, 0o600)
 
         second = Host(self.env)
         self.addCleanup(second.cleanup)
-        second_enabled = second.request(
-            {"type": "control.handshake", "protocol": 1, "enable": True}
-        )
-        second_instance = second_enabled["instance"]
-        stdout, stderr = self.run_cli("tabopen wrong.example")
+        second_instance = self.enable(second)
+        process, stdout, stderr = self.run_cli("tabopen wrong.example")
+        self.assertNotEqual(process.returncode, 0)
         self.assertEqual(stdout, "")
-        self.assertIn("multiple opted-in native hosts", stderr.lower())
+        self.assertIn("multiple opted-in native hosts", stderr)
         self.assertIn(instance, stderr)
         self.assertIn(second_instance, stderr)
         self.assertFalse(stale_path.exists())
-        self.assertFalse(invalid_pid_path.exists())
-        self.assert_no_native_output(host)
-        self.assert_no_native_output(second)
 
         cli = self.start_cli("tabopen example.com", instance[:8])
         request = host.receive()
-        self.assertEqual(request["type"], "control.request")
-        self.assertEqual(request["protocol"], 1)
-        self.assertEqual(request["operation"], "ex")
         self.assertEqual(request["command"], "tabopen example.com")
-        self.assert_no_native_output(second)
-        host.send(
-            {
-                "type": "control.response",
-                "protocol": 1,
-                "id": "not-" + request["id"],
-                "ok": True,
-                "result": "wrong",
-            }
-        )
-        time.sleep(0.1)
+        self.respond(host, {**request, "id": "wrong"}, result="wrong")
+        time.sleep(0.05)
         self.assertIsNone(cli.poll())
-        host.send(
-            {
-                "type": "control.response",
-                "protocol": 1,
-                "id": request["id"],
-                "ok": True,
-                "result": "opened",
-            }
-        )
-        stdout, stderr = cli.communicate(timeout=5)
-        self.assertEqual(cli.returncode, 0)
-        self.assertEqual(stdout, "opened\n")
-        self.assertEqual(stderr, "")
+        self.respond(host, request, result="opened")
+        self.assertEqual(cli.communicate(timeout=5), ("opened\n", ""))
 
         second.close_stdin()
         self.assertEqual(second.wait(), 0, second.stderr())
-        self.assertFalse(any(second_instance in path.name for path in self.records()))
 
         cli = self.start_cli("broken command")
         request = host.receive()
-        host.send(
-            {
-                "type": "control.response",
-                "protocol": 1,
-                "id": request["id"],
-                "ok": False,
-                "error": "command rejected",
-            }
-        )
+        self.respond(host, request, ok=False, error="command rejected")
         stdout, stderr = cli.communicate(timeout=5)
         self.assertNotEqual(cli.returncode, 0)
         self.assertEqual(stdout, "")
         self.assertIn("command rejected", stderr)
 
-        cli_one = self.start_cli("first concurrent command")
-        cli_two = self.start_cli("second concurrent command")
-        concurrent = [host.receive(), host.receive()]
-        by_command = {request["command"]: request for request in concurrent}
-        for command, result in (
-            ("second concurrent command", "second"),
-            ("first concurrent command", "first"),
-        ):
-            host.send(
-                {
-                    "type": "control.response",
-                    "protocol": 1,
-                    "id": by_command[command]["id"],
-                    "ok": True,
-                    "result": result,
-                }
-            )
-        self.assertEqual(cli_one.communicate(timeout=5), ("first\n", ""))
-        self.assertEqual(cli_two.communicate(timeout=5), ("second\n", ""))
+        time.sleep(0.05)
+        commands = [f"concurrent command {index}" for index in range(32)]
+        clients = {command: self.start_cli(command) for command in commands}
+        requests = {}
+        for _ in commands:
+            request = host.receive()
+            requests[request["command"]] = request
+        self.assertEqual(set(requests), set(commands))
+        overflow = self.start_cli("overflow command")
+        _, stderr = overflow.communicate(timeout=5)
+        self.assertNotEqual(overflow.returncode, 0)
+        self.assertIn("could not contact", stderr)
+        for command in reversed(commands):
+            self.respond(host, requests[command], result=command)
+        for command, process in clients.items():
+            self.assertEqual(process.communicate(timeout=5), (command + "\n", ""))
 
-        pending_one = self.start_cli("first pending command")
-        pending_two = self.start_cli("second pending command")
-        self.assertEqual(host.receive()["operation"], "ex")
-        self.assertEqual(host.receive()["operation"], "ex")
-        slow_client = socket.create_connection(("127.0.0.1", record["port"]), timeout=1)
-        slow_client.sendall(b"\x01")
+        pending = self.start_cli("pending command")
+        self.assertEqual(host.receive()["command"], "pending command")
+        slow = socket.create_connection(
+            ("127.0.0.1", json.loads(self.records()[0].read_text())["port"])
+        )
+        slow.sendall(b"{")
         host.close_stdin()
-        for cli in (pending_one, pending_two):
-            stdout, stderr = cli.communicate(timeout=5)
-            self.assertNotEqual(cli.returncode, 0)
-            self.assertEqual(stdout, "")
-            self.assertIn("extension disconnected", stderr.lower())
+        stdout, stderr = pending.communicate(timeout=5)
+        self.assertEqual(stdout, "")
+        self.assertIn("extension disconnected", stderr)
         self.assertEqual(host.wait(), 0, host.stderr())
-        slow_client.close()
+        slow.close()
         self.assertEqual(self.records(), [])
 
-    def test_legacy_one_shot(self):
+    def test_legacy_one_shot_and_cli_flags(self):
         version = subprocess.run(
-            [BINARY, "--version"],
-            check=True,
-            capture_output=True,
-            text=True,
+            [BINARY, "--version"], check=True, capture_output=True, text=True,
             env=self.env,
         )
         self.assertEqual(version.stdout, "0.6.0\n")
-        help_output = subprocess.run(
-            [BINARY, "--help"],
-            check=True,
+        empty_instance = subprocess.run(
+            [BINARY, "--request", "reload", "--instance", ""],
             capture_output=True,
-            text=True,
             env=self.env,
         )
-        self.assertIn("--request COMMAND", help_output.stdout)
+        self.assertEqual(empty_instance.returncode, 2)
         with subprocess.Popen(
-            [BINARY, "firefox-manifest", "extension-id"], stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=self.env,
+            [BINARY, "firefox-manifest", "extension-id"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env,
         ) as process:
             stdout, stderr = process.communicate(
                 native_frame({"cmd": "version"}), timeout=5
             )
-            self.assertEqual(process.returncode, 0, stderr.decode(errors="replace"))
+        self.assertEqual(process.returncode, 0, stderr.decode(errors="replace"))
         size = struct.unpack("=I", stdout[:4])[0]
-        response = json.loads(stdout[4 : 4 + size])
-        self.assertEqual(response["version"], "0.6.0")
+        self.assertEqual(json.loads(stdout[4 : 4 + size])["version"], "0.6.0")
         self.assertEqual(len(stdout), size + 4)
-        self.assertEqual(self.records(), [])
 
     def test_oversized_native_frame_is_rejected(self):
         host = Host(self.env)
         self.addCleanup(host.cleanup)
-
+        assert host.stdin is not None
         host.stdin.write(struct.pack("=I", MAX_NATIVE_FRAME + 1))
         host.stdin.flush()
-
         self.assertEqual(host.wait(), 0)
         self.assertIn("exceeds maximum frame length", host.stderr())
 

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import queue
+import socket
+import struct
+import subprocess
+import threading
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BINARY = ROOT / ("native_main.exe" if os.name == "nt" else "native_main")
+MAX_CLI_FRAME = 1024 * 1024
+MAX_NATIVE_FRAME = 64 * 1024 * 1024
+
+
+def frame(payload):
+    if not isinstance(payload, bytes):
+        payload = json.dumps(payload, separators=(",", ":")).encode()
+    return struct.pack("<I", len(payload)) + payload
+
+
+def native_frame(payload):
+    if not isinstance(payload, bytes):
+        payload = json.dumps(payload, separators=(",", ":")).encode()
+    return struct.pack("=I", len(payload)) + payload
+
+
+def read_exact(stream, size):
+    data = bytearray()
+    while len(data) < size:
+        chunk = stream.read(size - len(data))
+        if not chunk:
+            raise EOFError(f"wanted {size} bytes, got {len(data)}")
+        data.extend(chunk)
+    return bytes(data)
+
+
+def read_message(stream):
+    size = struct.unpack("=I", read_exact(stream, 4))[0]
+    return json.loads(read_exact(stream, size))
+
+
+def recv_exact(sock, size):
+    data = bytearray()
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            raise EOFError(f"wanted {size} bytes, got {len(data)}")
+        data.extend(chunk)
+    return bytes(data)
+
+
+def recv_message(sock):
+    size = struct.unpack("<I", recv_exact(sock, 4))[0]
+    return json.loads(recv_exact(sock, size))
+
+
+def authenticate(sock, record):
+    challenge = os.urandom(16).hex()
+    sock.sendall(frame({"protocol": 1, "challenge": challenge}))
+    response = recv_message(sock)
+    expected = hashlib.sha1((record["token"] + challenge).encode()).hexdigest()
+    if (
+        response.get("protocol") != 1
+        or response.get("instance") != record["instance"]
+        or response.get("proof", "").lower() != expected
+    ):
+        raise AssertionError("control host failed authentication")
+
+
+class Host:
+    def __init__(self, env):
+        self.process = subprocess.Popen(
+            [BINARY],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+        assert self.process.stdin is not None
+        assert self.process.stdout is not None
+        assert self.process.stderr is not None
+        self.stdin = self.process.stdin
+        self.stdout = self.process.stdout
+        self.stderr_stream = self.process.stderr
+        self.messages = queue.Queue()
+        self.reader = threading.Thread(target=self._read_messages, daemon=True)
+        self.reader.start()
+
+    def _read_messages(self):
+        try:
+            while True:
+                self.messages.put(read_message(self.stdout))
+        except EOFError:
+            pass
+        except Exception as error:
+            self.messages.put(error)
+
+    def send(self, message):
+        self.stdin.write(native_frame(message))
+        self.stdin.flush()
+
+    def receive(self):
+        message = self.messages.get(timeout=5)
+        if isinstance(message, Exception):
+            raise message
+        return message
+
+    def request(self, message):
+        self.send(message)
+        return self.receive()
+
+    def close_stdin(self):
+        self.stdin.close()
+
+    def wait(self):
+        return self.process.wait(timeout=5)
+
+    def stderr(self):
+        return self.stderr_stream.read().decode(errors="replace")
+
+    def cleanup(self):
+        if self.process.poll() is None:
+            self.process.kill()
+            self.process.wait()
+        self.reader.join(timeout=1)
+        for stream in (self.stdin, self.stdout, self.stderr_stream):
+            stream.close()
+
+
+class NativeControlTest(unittest.TestCase):
+    def setUp(self):
+        if not BINARY.exists():
+            self.fail("native_main is missing; run `nimble build` before this test")
+        self.cache = tempfile.TemporaryDirectory()
+        self.addCleanup(self.cache.cleanup)
+        self.env = os.environ.copy()
+        self.env["XDG_CACHE_HOME"] = self.cache.name
+        self.env["LOCALAPPDATA"] = self.cache.name
+        self.env["HOME"] = self.cache.name
+        self.env["USERPROFILE"] = self.cache.name
+
+    def records(self):
+        return list(Path(self.cache.name).glob("**/native-control/*.json"))
+
+    def start_cli(self, command, instance=None):
+        args = [BINARY, "--request", command]
+        if instance:
+            args.extend(["--instance", instance])
+        return subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=self.env,
+        )
+
+    def run_cli(self, command, instance=None):
+        return self.start_cli(command, instance).communicate(timeout=5)
+
+    def assert_no_native_output(self, host):
+        with self.assertRaises(queue.Empty):
+            host.messages.get(timeout=0.2)
+
+    def test_legacy_control_cli_and_shutdown(self):
+        host = Host(self.env)
+        self.addCleanup(host.cleanup)
+
+        version = host.request({"cmd": "version"})
+        self.assertEqual(version["cmd"], "version")
+        self.assertEqual(version["version"], "0.6.0")
+        self.assertEqual(version["code"], 0)
+        self.assertIn("control-port-v1", version["capabilities"])
+        self.assertEqual(self.records(), [])
+
+        stdout, stderr = self.run_cli("tabopen example.com")
+        self.assertEqual(stdout, "")
+        self.assertIn("no opted-in native host", stderr.lower())
+
+        host.send(b"{not-json")
+        malformed = host.receive()
+        self.assertEqual(malformed["cmd"], "error")
+        self.assertIn("malformed", malformed["error"].lower())
+        malformed = host.request({"cmd": "run"})
+        self.assertEqual(malformed["cmd"], "error")
+        self.assertEqual(host.request({"cmd": "version"})["version"], "0.6.0")
+        invalid_protocol = host.request(
+            {"type": "control.handshake", "protocol": 2**40, "enable": True}
+        )
+        self.assertFalse(invalid_protocol["enabled"])
+        self.assertEqual(host.request({"cmd": "version"})["version"], "0.6.0")
+
+        disabled = host.request(
+            {"type": "control.handshake", "protocol": 1, "enable": False}
+        )
+        self.assertEqual(
+            disabled,
+            {"type": "control.handshake", "protocol": 1, "enabled": False},
+        )
+        self.assertEqual(self.records(), [])
+
+        enabled = host.request(
+            {"type": "control.handshake", "protocol": 1, "enable": True}
+        )
+        self.assertTrue(enabled["enabled"])
+        instance = enabled["instance"]
+        record_path = self.records()[0]
+        discovery_dir = record_path.parent
+        record = json.loads(record_path.read_text())
+        self.assertEqual(record["instance"], instance)
+        self.assertEqual(record["protocol"], 1)
+        if os.name == "posix":
+            self.assertEqual(record_path.stat().st_mode & 0o077, 0)
+            self.assertEqual(discovery_dir.stat().st_mode & 0o077, 0)
+
+        saturated = [
+            socket.create_connection(("127.0.0.1", record["port"]), timeout=1)
+            for _ in range(40)
+        ]
+        try:
+            stdout, stderr = self.run_cli("tabopen saturated.example")
+            self.assertEqual(stdout, "")
+            self.assertIn("no opted-in native host", stderr.lower())
+            self.assertTrue(record_path.exists())
+        finally:
+            for client in saturated:
+                client.close()
+
+        with socket.create_connection(("127.0.0.1", record["port"]), timeout=1) as sock:
+            authenticate(sock, record)
+            sock.sendall(
+                frame(
+                    {
+                        "protocol": 1,
+                        "token": "wrong",
+                        "operation": "ex",
+                        "command": "quitall",
+                    }
+                )
+            )
+            self.assertFalse(recv_message(sock)["ok"])
+        self.assert_no_native_output(host)
+
+        with socket.create_connection(("127.0.0.1", record["port"]), timeout=1) as sock:
+            authenticate(sock, record)
+            sock.sendall(struct.pack("<I", MAX_CLI_FRAME + 1))
+            self.assertFalse(recv_message(sock)["ok"])
+        self.assert_no_native_output(host)
+
+        reset = socket.create_connection(("127.0.0.1", record["port"]), timeout=1)
+        authenticate(reset, record)
+        reset.sendall(
+            frame(
+                {
+                    "protocol": 1,
+                    "token": "wrong",
+                    "operation": "ex",
+                    "command": "quitall",
+                }
+            )
+        )
+        reset.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+        reset.close()
+        self.assertEqual(host.request({"cmd": "version"})["version"], "0.6.0")
+
+        stale_path = discovery_dir / ("0" * 32 + ".json")
+        stale_path.write_text(
+            json.dumps(
+                {
+                    "protocol": 1,
+                    "instance": "0" * 32,
+                    "port": 1,
+                    "token": "0" * 64,
+                    "pid": 999999999,
+                }
+            )
+        )
+        os.chmod(stale_path, 0o600)
+        invalid_pid_path = discovery_dir / ("1" * 32 + ".json")
+        invalid_pid_path.write_text(
+            json.dumps(
+                {
+                    "protocol": 1,
+                    "instance": "1" * 32,
+                    "port": 1,
+                    "token": "1" * 64,
+                    "pid": 2**31,
+                }
+            )
+        )
+        os.chmod(invalid_pid_path, 0o600)
+
+        second = Host(self.env)
+        self.addCleanup(second.cleanup)
+        second_enabled = second.request(
+            {"type": "control.handshake", "protocol": 1, "enable": True}
+        )
+        second_instance = second_enabled["instance"]
+        stdout, stderr = self.run_cli("tabopen wrong.example")
+        self.assertEqual(stdout, "")
+        self.assertIn("multiple opted-in native hosts", stderr.lower())
+        self.assertIn(instance, stderr)
+        self.assertIn(second_instance, stderr)
+        self.assertFalse(stale_path.exists())
+        self.assertFalse(invalid_pid_path.exists())
+        self.assert_no_native_output(host)
+        self.assert_no_native_output(second)
+
+        cli = self.start_cli("tabopen example.com", instance[:8])
+        request = host.receive()
+        self.assertEqual(request["type"], "control.request")
+        self.assertEqual(request["protocol"], 1)
+        self.assertEqual(request["operation"], "ex")
+        self.assertEqual(request["command"], "tabopen example.com")
+        self.assert_no_native_output(second)
+        host.send(
+            {
+                "type": "control.response",
+                "protocol": 1,
+                "id": "not-" + request["id"],
+                "ok": True,
+                "result": "wrong",
+            }
+        )
+        time.sleep(0.1)
+        self.assertIsNone(cli.poll())
+        host.send(
+            {
+                "type": "control.response",
+                "protocol": 1,
+                "id": request["id"],
+                "ok": True,
+                "result": "opened",
+            }
+        )
+        stdout, stderr = cli.communicate(timeout=5)
+        self.assertEqual(cli.returncode, 0)
+        self.assertEqual(stdout, "opened\n")
+        self.assertEqual(stderr, "")
+
+        second.close_stdin()
+        self.assertEqual(second.wait(), 0, second.stderr())
+        self.assertFalse(any(second_instance in path.name for path in self.records()))
+
+        cli = self.start_cli("broken command")
+        request = host.receive()
+        host.send(
+            {
+                "type": "control.response",
+                "protocol": 1,
+                "id": request["id"],
+                "ok": False,
+                "error": "command rejected",
+            }
+        )
+        stdout, stderr = cli.communicate(timeout=5)
+        self.assertNotEqual(cli.returncode, 0)
+        self.assertEqual(stdout, "")
+        self.assertIn("command rejected", stderr)
+
+        cli_one = self.start_cli("first concurrent command")
+        cli_two = self.start_cli("second concurrent command")
+        concurrent = [host.receive(), host.receive()]
+        by_command = {request["command"]: request for request in concurrent}
+        for command, result in (
+            ("second concurrent command", "second"),
+            ("first concurrent command", "first"),
+        ):
+            host.send(
+                {
+                    "type": "control.response",
+                    "protocol": 1,
+                    "id": by_command[command]["id"],
+                    "ok": True,
+                    "result": result,
+                }
+            )
+        self.assertEqual(cli_one.communicate(timeout=5), ("first\n", ""))
+        self.assertEqual(cli_two.communicate(timeout=5), ("second\n", ""))
+
+        pending_one = self.start_cli("first pending command")
+        pending_two = self.start_cli("second pending command")
+        self.assertEqual(host.receive()["operation"], "ex")
+        self.assertEqual(host.receive()["operation"], "ex")
+        slow_client = socket.create_connection(("127.0.0.1", record["port"]), timeout=1)
+        slow_client.sendall(b"\x01")
+        host.close_stdin()
+        for cli in (pending_one, pending_two):
+            stdout, stderr = cli.communicate(timeout=5)
+            self.assertNotEqual(cli.returncode, 0)
+            self.assertEqual(stdout, "")
+            self.assertIn("extension disconnected", stderr.lower())
+        self.assertEqual(host.wait(), 0, host.stderr())
+        slow_client.close()
+        self.assertEqual(self.records(), [])
+
+    def test_legacy_one_shot(self):
+        version = subprocess.run(
+            [BINARY, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=self.env,
+        )
+        self.assertEqual(version.stdout, "0.6.0\n")
+        help_output = subprocess.run(
+            [BINARY, "--help"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=self.env,
+        )
+        self.assertIn("--request COMMAND", help_output.stdout)
+        with subprocess.Popen(
+            [BINARY, "firefox-manifest", "extension-id"], stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=self.env,
+        ) as process:
+            stdout, stderr = process.communicate(
+                native_frame({"cmd": "version"}), timeout=5
+            )
+            self.assertEqual(process.returncode, 0, stderr.decode(errors="replace"))
+        size = struct.unpack("=I", stdout[:4])[0]
+        response = json.loads(stdout[4 : 4 + size])
+        self.assertEqual(response["version"], "0.6.0")
+        self.assertEqual(len(stdout), size + 4)
+        self.assertEqual(self.records(), [])
+
+    def test_oversized_native_frame_is_rejected(self):
+        host = Host(self.env)
+        self.addCleanup(host.cleanup)
+
+        host.stdin.write(struct.pack("=I", MAX_NATIVE_FRAME + 1))
+        host.stdin.flush()
+
+        self.assertEqual(host.wait(), 0)
+        self.assertIn("exceeds maximum frame length", host.stderr())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tridactyl_native.nimble
+++ b/tridactyl_native.nimble
@@ -3,11 +3,18 @@
 author        = "Oliver Blanthorn"
 description   = "Native messenger for Tridactyl, a vim-like web-extension"
 license       = "BSD-2"
+version       = "0.6.0"
 srcDir        = "src"
 bin           = @["native_main"]
 
 # Dependencies
 
-requires "nim >= 1.2.0"
+requires "nim >= 2.0.0"
 requires "tempfile >= 0.1.0"
 requires "regex >= 0.20.2"
+
+task test, "Run protocol and CLI integration tests":
+  when defined(windows):
+    exec "python tests/test_native.py"
+  else:
+    exec "python3 tests/test_native.py"


### PR DESCRIPTION
```
nimble build -Y
./installers/install.sh local
```

from Tridactyl

```
:set nativecontrol true
```

from a terminal

```
~/.local/share/tridactyl/native_main --request 'tabopen example.org'
```

my security design so far is that if you have access to the user account you're beyond the security boundary and it's all fair game. unix sockets would have been nice but they're not very cross platform, so going for boring TCP port listening on 127.0.0.1 with a shared secret auth token readable only by the user. as a bonus it means you can hack on it by forwarding that port somewhere and sharing the secret.
